### PR TITLE
fix Windows directory reveal actions

### DIFF
--- a/cmd/milksu-backend/app.go
+++ b/cmd/milksu-backend/app.go
@@ -610,19 +610,6 @@ func (a *App) ExportLocalDiagnostics() (appdata.DiagnosticExport, error) {
 	)
 }
 
-func (a *App) RevealLocalDataDirectory() error {
-	if a.ctx == nil {
-		return fmt.Errorf("desktop runtime is not ready")
-	}
-	if runtime.GOOS != "darwin" {
-		return fmt.Errorf("reveal local data directory is currently supported on macOS")
-	}
-	if err := exec.Command("/usr/bin/open", a.dataDirectory).Run(); err != nil {
-		return fmt.Errorf("open local data directory: %w", err)
-	}
-	return nil
-}
-
 type UserArtifactDirectoryStatus struct {
 	Directory string `json:"directory"`
 }
@@ -633,23 +620,6 @@ func (a *App) GetUserArtifactDirectoryStatus() UserArtifactDirectoryStatus {
 
 func (a *App) EnsureCodingArtifactWorkspace(conversationID string) (string, error) {
 	return a.resolveConversationWorkspace(conversationID, "")
-}
-
-func (a *App) RevealUserArtifactDirectory() error {
-	if a.ctx == nil {
-		return fmt.Errorf("desktop runtime is not ready")
-	}
-	if runtime.GOOS != "darwin" {
-		return fmt.Errorf("reveal user artifact directory is currently supported on macOS")
-	}
-	root, err := userartifact.Ensure(a.artifactDirectory)
-	if err != nil {
-		return err
-	}
-	if err := exec.Command("/usr/bin/open", root).Run(); err != nil {
-		return fmt.Errorf("open user artifact directory: %w", err)
-	}
-	return nil
 }
 
 func (a *App) SaveSettingsCmd(settings config.AppSettings) error {

--- a/cmd/milksu-backend/app_local_paths.go
+++ b/cmd/milksu-backend/app_local_paths.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/MilkSU-Official/milksu/internal/userartifact"
+)
+
+func (a *App) RevealLocalDataDirectory() error {
+	if a.ctx == nil {
+		return fmt.Errorf("desktop runtime is not ready")
+	}
+	return a.openPath(a.dataDirectory)
+}
+
+func (a *App) RevealUserArtifactDirectory() error {
+	if a.ctx == nil {
+		return fmt.Errorf("desktop runtime is not ready")
+	}
+	root, err := userartifact.Ensure(a.artifactDirectory)
+	if err != nil {
+		return err
+	}
+	return a.openPath(root)
+}

--- a/cmd/milksu-backend/app_local_paths_test.go
+++ b/cmd/milksu-backend/app_local_paths_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRevealLocalDataDirectoryDelegatesToDesktopHost(t *testing.T) {
+	host := &stubDesktopHost{}
+	directory := filepath.Join(t.TempDir(), "local data")
+	app := &App{ctx: context.Background(), host: host, dataDirectory: directory}
+
+	if err := app.RevealLocalDataDirectory(); err != nil {
+		t.Fatalf("reveal local data directory: %v", err)
+	}
+	assertOpenPathCall(t, host, directory)
+}
+
+func TestRevealUserArtifactDirectoryEnsuresAndDelegatesToDesktopHost(t *testing.T) {
+	host := &stubDesktopHost{}
+	directory := filepath.Join(t.TempDir(), "Documents", "MilkSU")
+	app := &App{ctx: context.Background(), host: host, artifactDirectory: directory}
+
+	if err := app.RevealUserArtifactDirectory(); err != nil {
+		t.Fatalf("reveal user artifact directory: %v", err)
+	}
+	if info, err := os.Stat(directory); err != nil || !info.IsDir() {
+		t.Fatalf("artifact directory was not ensured: %v", err)
+	}
+	assertOpenPathCall(t, host, directory)
+}
+
+func TestRevealLocalDataDirectorySurfacesHostFailure(t *testing.T) {
+	host := &stubDesktopHost{err: errors.New("shell unavailable")}
+	app := &App{
+		ctx: context.Background(), host: host,
+		dataDirectory: filepath.Join(t.TempDir(), "local data"),
+	}
+
+	if err := app.RevealLocalDataDirectory(); err == nil || err.Error() != "shell unavailable" {
+		t.Fatalf("expected host failure, got %v", err)
+	}
+}
+
+func assertOpenPathCall(t *testing.T, host *stubDesktopHost, want string) {
+	t.Helper()
+	if len(host.calls) != 1 || host.calls[0] != "shell.openPath" {
+		t.Fatalf("unexpected host calls: %#v", host.calls)
+	}
+	payload, ok := host.payload.(map[string]string)
+	if !ok || payload["path"] != want {
+		t.Fatalf("unexpected open path payload: %#v", host.payload)
+	}
+}

--- a/cmd/milksu-backend/desktop_host.go
+++ b/cmd/milksu-backend/desktop_host.go
@@ -90,6 +90,10 @@ func (a *App) openExternal(target string) error {
 	return a.desktopCall("shell.openExternal", map[string]string{"url": target}, nil)
 }
 
+func (a *App) openPath(target string) error {
+	return a.desktopCall("shell.openPath", map[string]string{"path": target}, nil)
+}
+
 type electronCodingHost struct {
 	host desktopHost
 }

--- a/desktop/local-path.cjs
+++ b/desktop/local-path.cjs
@@ -1,0 +1,25 @@
+'use strict'
+
+const path = require('node:path')
+
+async function openLocalPath(target, { stat, openPath }) {
+  const resolved = String(target ?? '').trim()
+  if (!resolved || !path.isAbsolute(resolved)) {
+    throw new Error('local path must be absolute')
+  }
+
+  let metadata
+  try {
+    metadata = await stat(resolved)
+  } catch (error) {
+    throw new Error(`local path is unavailable: ${error.message}`)
+  }
+  if (!metadata.isDirectory() && !metadata.isFile()) {
+    throw new Error('local path is not a file or directory')
+  }
+
+  const errorMessage = await openPath(resolved)
+  if (errorMessage) throw new Error(`open local path: ${errorMessage}`)
+}
+
+module.exports = { openLocalPath }

--- a/desktop/local-path.test.cjs
+++ b/desktop/local-path.test.cjs
@@ -1,0 +1,68 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const test = require('node:test')
+
+const { openLocalPath } = require('./local-path.cjs')
+
+test('openLocalPath opens an existing absolute directory without rewriting it', async () => {
+  const target = path.resolve('产物 directory')
+  const opened = []
+
+  await openLocalPath(target, {
+    stat: async value => {
+      assert.equal(value, target)
+      return { isDirectory: () => true, isFile: () => false }
+    },
+    openPath: async value => {
+      opened.push(value)
+      return ''
+    },
+  })
+
+  assert.deepEqual(opened, [target])
+})
+
+test('openLocalPath rejects relative and unavailable paths before opening', async () => {
+  let opened = false
+  const openPath = async () => {
+    opened = true
+    return ''
+  }
+
+  await assert.rejects(
+    openLocalPath('relative/path', {
+      stat: async () => ({ isDirectory: () => true, isFile: () => false }),
+      openPath,
+    }),
+    /must be absolute/u,
+  )
+  await assert.rejects(
+    openLocalPath(path.resolve('missing'), {
+      stat: async () => { throw new Error('missing') },
+      openPath,
+    }),
+    /local path is unavailable: missing/u,
+  )
+  assert.equal(opened, false)
+})
+
+test('openLocalPath rejects special files and surfaces shell failures', async () => {
+  const target = path.resolve('target')
+
+  await assert.rejects(
+    openLocalPath(target, {
+      stat: async () => ({ isDirectory: () => false, isFile: () => false }),
+      openPath: async () => '',
+    }),
+    /not a file or directory/u,
+  )
+  await assert.rejects(
+    openLocalPath(target, {
+      stat: async () => ({ isDirectory: () => false, isFile: () => true }),
+      openPath: async () => 'no application is associated',
+    }),
+    /open local path: no application is associated/u,
+  )
+})

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -48,6 +48,7 @@ const {
   shouldRelaunchAfterScreenRecordingGrant,
 } = require('./computer-use-permissions.cjs')
 const { requestMacOSScreenPermission } = require('./macos-screen-permission.cjs')
+const { openLocalPath } = require('./local-path.cjs')
 
 const APP_ORIGIN = 'milksu://app'
 const METHOD_PATTERN = /^[A-Z][A-Za-z0-9]{0,80}$/u
@@ -540,6 +541,12 @@ async function handleHostRequest(method, payload = {}) {
       await shell.openExternal(url.toString())
       return null
     }
+    case 'shell.openPath':
+      await openLocalPath(payload.path, {
+        stat: target => fs.stat(target),
+        openPath: target => shell.openPath(target),
+      })
+      return null
     case 'window.show':
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.show()

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,6 +34,7 @@
       "browser-view-attachment.cjs",
       "update-manager.cjs",
       "computer-use-permissions.cjs",
+      "local-path.cjs",
       "macos-screen-permission.cjs",
       "renderer-protocol.cjs",
       "package.json",

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -52,6 +52,7 @@
 - 桌面壳是 Electron/Chromium + Vue；Go 是受管 Runtime，Pi Sidecar 拥有通用模型会话、Compaction 与 Tool Loop。
 - 右栏“浏览器”、真实 Chrome/Edge 的 Browser Use、外部 App 的 Computer Use 是三个独立执行表面。折叠面板只改变观察视图，不应停止 Session。
 - 用户可见产物写入各操作系统的用户文档目录下 `MilkSU/{Coding,CTF,CVE}`；无项目 Coding 临时工作区、Runtime、事件、Obelisk、浏览器 Profile 与凭据留在平台用户配置目录，不把 macOS 路径写死为产品契约。
+- Windows `26.817.3` 的设置页“打开产物目录”和“打开数据目录”曾因 Go Reveal 实现写死 macOS `/usr/bin/open` 而无法使用；当前开发分支改为由 Go 确定受信任路径、Electron Host 统一调用平台 `shell.openPath`，定向 Go/Desktop 测试已通过；新的正式 Windows 包尚未发行。
 - Obelisk 会话索引底层继续保留；Coding 右栏与环境页已移除“相关历史”、搜索、过滤和图谱等单会话前端。学习记录/记忆系统如重新进入产品，应单独设计页面。
 - 日间/夜间模式共用中性纸面/暖石墨层级，酸绿只用于选择、主操作和活动强度；CTF、CVE、Coding 不以旧蓝黑色块区分。
 


### PR DESCRIPTION
## Summary

- route the General settings data and artifact directory actions through an Electron desktop-host method
- open validated absolute local paths with Electron's platform-native `shell.openPath`
- keep trusted directory selection and artifact-directory creation in the Go app service
- add focused Go and Desktop tests, and record the Windows status in current objectives

## Root cause

The settings buttons and frontend-to-Go RPC wiring were working. The two Go reveal methods explicitly rejected every operating system except macOS and then launched `/usr/bin/open`. On Windows, the request therefore failed in the app service before the operating system shell was ever called.

The Electron host already handled web URLs through `shell.openExternal`, but it had no corresponding local-path host method.

## Why this fix

Go continues to choose the trusted application-owned path. The Electron host is the platform adapter and uses `shell.openPath`, which delegates to Explorer on Windows and the native shell on other supported platforms. The adapter rejects empty or relative paths, verifies that the target exists and is a file or directory, preserves Unicode and spaces, and propagates Electron's error result.

This avoids platform-specific command construction such as `cmd /c start`, `explorer.exe`, or `/usr/bin/open` in the Go service.

## Validation

- `go test ./cmd/milksu-backend -run 'TestReveal(LocalDataDirectory|UserArtifactDirectory)' -count=1 -v` — 3 passed
- `node --test desktop/local-path.test.cjs desktop/package-files.test.cjs` — 4 passed
- `git diff --check` — passed
- full Desktop suite: 48/50 passed; the two Windows-only failures reproduce unchanged on the untouched source snapshot (packaged resource seal expectation and POSIX browser-profile path expectation)
- full Go package test compiled; its unrelated symlink test requires a Windows privilege unavailable to the current user

No new official Windows package has been produced from this branch yet.
