### PR TITLE
fix(ui): save custom relay as draft until confirmed and restore settings database compatibility row

### DIFF
--- a/app/src/components-vue/SettingsPage.test.ts
+++ b/app/src/components-vue/SettingsPage.test.ts
@@ -44,6 +44,12 @@ async function settle() {
   await nextTick()
 }
 
+function modelServiceRowTitles() {
+  return [...document.querySelectorAll('.model-service-row')].map(row => (
+    (row.querySelector('p.font-medium')?.textContent ?? '').trim()
+  ))
+}
+
 afterEach(() => {
   for (const app of mountedApps.splice(0)) app.unmount()
   document.body.innerHTML = ''
@@ -899,6 +905,133 @@ describe('SettingsPage database compatibility', () => {
       api_key: 'custom-test-secret',
     })
     expect(document.body.textContent).toContain('已保存并验证')
+    expect(modelServiceRowTitles()).toContain('MilkSU 账户')
+    expect(modelServiceRowTitles()).toContain('我的 Grok 中转站')
+  })
+
+  it('does not add a custom relay row until the editor is saved', async () => {
+    const settings = withAppSettingsDefaults({
+      active_provider: 'tokenflux',
+      active_model: 'grok-4.5',
+      providers: {},
+    } as AppSettings)
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'apikeys',
+      settings,
+    })
+
+    document.querySelector<HTMLButtonElement>('button[aria-label="新增模型服务"]')?.click()
+    await settle()
+
+    expect(document.querySelector('.provider-editor-dialog')).not.toBeNull()
+    expect(modelServiceRowTitles()).toContain('MilkSU 账户')
+    expect(modelServiceRowTitles()).not.toContain('我的中转站')
+    expect(Object.keys(settings.providers).some(id => id.startsWith('custom-relay-'))).toBe(false)
+  })
+
+  it('discards an unsaved custom relay when the editor is closed', async () => {
+    let savedSettings: AppSettings | null = null
+    const settings = withAppSettingsDefaults({
+      active_provider: 'tokenflux',
+      active_model: 'grok-4.5',
+      providers: {},
+    } as AppSettings)
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'apikeys',
+      settings,
+      appMethods: {
+        SaveSettingsCmd: async (value: unknown) => {
+          savedSettings = value as AppSettings
+        },
+        GetSettings: async () => savedSettings ?? settings,
+        TestAgentModel: async () => ({
+          provider: 'tokenflux',
+          model: 'grok-4.5',
+          ready: true,
+          latencyMs: 20,
+        }),
+      },
+    })
+
+    document.querySelector<HTMLButtonElement>('button[aria-label="新增模型服务"]')?.click()
+    await settle()
+    const nameInput = document.querySelector<HTMLInputElement>('input[aria-label="中转站名称"]')
+    expect(nameInput).not.toBeNull()
+    nameInput!.value = '未保存的中转站'
+    nameInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    document.querySelector<HTMLButtonElement>('button[aria-label="Close"]')?.click()
+    await settle()
+
+    expect(document.querySelector('.provider-editor-dialog')).toBeNull()
+    expect(modelServiceRowTitles()).not.toContain('未保存的中转站')
+    expect(modelServiceRowTitles()).not.toContain('我的中转站')
+    expect(modelServiceRowTitles()).toContain('MilkSU 账户')
+
+    const saveButton = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent?.includes('保存并验证'))
+    saveButton?.click()
+    for (let index = 0; index < 6; index += 1) await settle()
+
+    expect(savedSettings).not.toBeNull()
+    expect(Object.keys(savedSettings!.providers).some(id => id.startsWith('custom-relay-'))).toBe(false)
+    expect(savedSettings!.active_provider).toBe('tokenflux')
+  })
+
+  it('keeps the MilkSU account row when a custom relay is the active default', async () => {
+    const settings = withAppSettingsDefaults({
+      active_provider: 'custom-relay-team',
+      active_model: 'vendor/model:preview',
+      relay: {
+        enabled: true,
+        url: 'https://tokenflux.dev/v1',
+        key: '',
+        has_key: true,
+      },
+      providers: {
+        'custom-relay-team': {
+          api_key: '',
+          has_api_key: true,
+          enabled: true,
+          custom: true,
+          name: 'Team Relay',
+          base_url: 'https://relay.example/v1',
+          models: ['vendor/model:preview'],
+        },
+      },
+    } as unknown as AppSettings)
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'apikeys',
+      settings,
+      accountStatus: {
+        configured: true,
+        authenticated: true,
+        state: 'active',
+        tokenFluxLinked: true,
+        user: {
+          githubLogin: 'milksuofficial',
+          displayName: 'MilkSU',
+          avatarUrl: '',
+        },
+      },
+    })
+
+    expect(modelServiceRowTitles()).toContain('MilkSU 账户')
+    expect(modelServiceRowTitles()).toContain('Team Relay')
+    const accountRow = [...document.querySelectorAll<HTMLElement>('.model-service-row')]
+      .find(row => row.textContent?.includes('MilkSU 账户'))
+    expect(accountRow?.querySelector('[role="switch"]')).not.toBeNull()
   })
 
   it('edits TokenFlux personal without silently replacing the default model service', async () => {

--- a/app/src/components-vue/SettingsPage.test.ts
+++ b/app/src/components-vue/SettingsPage.test.ts
@@ -419,6 +419,7 @@ describe('SettingsPage database compatibility', () => {
       relativePaths.some(path => li.textContent?.includes(path)),
     )
     expect(compatItems.length).toBeGreaterThanOrEqual(5)
+    expect(compatItems[0].closest('.mx-4')).not.toBeNull()
     const compatMarkup = compatItems.map(item => item.outerHTML).join('')
     expect(compatMarkup).not.toContain('凭据库')
 

--- a/app/src/components-vue/SettingsPage.vue
+++ b/app/src/components-vue/SettingsPage.vue
@@ -1224,9 +1224,12 @@ async function saveProviderEditor(closeAfterSave: boolean) {
                 诊断包只包含版本、运行状态、数据库健康检查和脱敏错误事件，便于排查启动与连接问题。
               </p>
             </SettingsRow>
-            <div v-if="localData?.databases?.length" class="mt-4 min-w-0">
-              <p class="text-control font-medium">数据库兼容性</p>
-              <ul class="mt-2 flex flex-col gap-3">
+            <SettingsRow
+              v-if="localData?.databases?.length"
+              stack="always"
+              label="数据库兼容性"
+            >
+              <ul class="flex min-w-0 flex-col gap-3">
                 <li
                   v-for="database in localData.databases"
                   :key="database.relativePath"
@@ -1255,7 +1258,7 @@ async function saveProviderEditor(closeAfterSave: boolean) {
                   </p>
                 </li>
               </ul>
-            </div>
+            </SettingsRow>
           </SettingsSection>
 
           <div class="mt-6 flex justify-end">

--- a/app/src/components-vue/SettingsPage.vue
+++ b/app/src/components-vue/SettingsPage.vue
@@ -74,6 +74,7 @@ import type {
   ProviderInfo,
 } from '@/types'
 import {
+  customProviderInfo,
   withAppSettingsDefaults,
 } from '@/types'
 import {
@@ -142,6 +143,7 @@ const buildTrackingCopying = ref(false)
 const notice = ref<{ tone: 'ok' | 'error'; text: string } | null>(null)
 const editingProviderID = ref<string | null>(null)
 const customModelInput = ref('')
+const pendingCustomRelay = ref<{ id: string; config: ProviderConfig } | null>(null)
 // Same callable-model surface as Coding composer (enabled services only).
 const pickerSettings = computed(() => ({
   providers: working.value?.providers ?? {},
@@ -389,7 +391,7 @@ function customRelayID() {
   return `custom-relay-${random}`
 }
 
-function addCustomRelay() {
+function addModelService() {
   if (!working.value) return
   const count = Object.values(working.value.providers).filter(item => item.custom).length
   if (count >= 8) {
@@ -397,30 +399,21 @@ function addCustomRelay() {
     return
   }
   const id = customRelayID()
-  working.value.providers[id] = {
-    api_key: '',
-    has_api_key: false,
-    base_url: '',
-    enabled: true,
-    custom: true,
-    name: '我的中转站',
-    models: [],
+  pendingCustomRelay.value = {
+    id,
+    config: {
+      api_key: '',
+      has_api_key: false,
+      base_url: '',
+      enabled: true,
+      custom: true,
+      name: '我的中转站',
+      models: [],
+    },
   }
-  working.value.active_provider = id
-  working.value.active_model = ''
+  editingProviderID.value = id
   customModelInput.value = ''
   notice.value = null
-}
-
-function addModelService() {
-  const previousProvider = working.value?.active_provider
-  addCustomRelay()
-  if (
-    working.value?.active_provider !== previousProvider
-    && working.value?.active_provider.startsWith('custom-relay-')
-  ) {
-    editingProviderID.value = working.value.active_provider
-  }
 }
 
 function removeModelService(id: string) {
@@ -488,8 +481,6 @@ function ensureAccountRoute() {
 }
 
 const accountModelSourceReady = computed(() => Boolean(
-  !provider.value?.custom
-  &&
   account.value.state === 'active'
   && account.value.tokenFluxLinked === true,
 ))
@@ -499,11 +490,9 @@ type ModelServiceRow =
 
 const modelServiceRows = computed<ModelServiceRow[]>(() => {
   if (!working.value) return []
-  const rows: ModelServiceRow[] = []
-  // Account first when TokenFlux is the product model route; then every provider service.
-  if (!provider.value?.custom) {
-    rows.push({ key: 'account', source: 'account' })
-  }
+  const rows: ModelServiceRow[] = [
+    { key: 'account', source: 'account' },
+  ]
   for (const item of modelProviders.value) {
     rows.push({ key: `provider:${item.id}`, source: 'personal', provider: item })
   }
@@ -511,12 +500,19 @@ const modelServiceRows = computed<ModelServiceRow[]>(() => {
 })
 
 const accountProviderInfo = computed(() => modelProviders.value.find(item => item.id === 'tokenflux'))
-const editingProviderInfo = computed(() => (
-  modelProviders.value.find(item => item.id === editingProviderID.value)
-))
-const editingProvider = computed(() => (
-  editingProviderID.value ? working.value?.providers[editingProviderID.value] : undefined
-))
+const editingProviderInfo = computed(() => {
+  if (pendingCustomRelay.value?.id === editingProviderID.value) {
+    return customProviderInfo(pendingCustomRelay.value.id, pendingCustomRelay.value.config) ?? undefined
+  }
+  return modelProviders.value.find(item => item.id === editingProviderID.value)
+})
+const editingProvider = computed(() => {
+  if (!editingProviderID.value) return undefined
+  if (pendingCustomRelay.value?.id === editingProviderID.value) {
+    return pendingCustomRelay.value.config
+  }
+  return working.value?.providers[editingProviderID.value]
+})
 const editingProviderModel = computed(() => {
   if (!editingProviderInfo.value || !working.value) return ''
   if (editingProviderID.value === working.value.active_provider) return working.value.active_model
@@ -531,6 +527,7 @@ const providerEditorOpen = computed({
   get: () => Boolean(editingProviderID.value),
   set: value => {
     if (!value) {
+      pendingCustomRelay.value = null
       editingProviderID.value = null
       customModelInput.value = ''
     }
@@ -612,7 +609,6 @@ function setEditingProviderModel(value: string) {
 function setModelServiceEnabled(row: ModelServiceRow, enabled: boolean) {
   if (!working.value) return
   if (row.source === 'account') {
-    if (provider.value?.custom) return
     ensureAccountRoute()
     if (enabled && !accountModelSourceReady.value) {
       working.value.relay!.enabled = false
@@ -956,23 +952,23 @@ async function refreshCallableModels() {
   alignDefaultModelToEnabledServices()
 }
 
-async function save() {
-  if (!working.value) return
+async function save(): Promise<boolean> {
+  if (!working.value) return false
   const incompleteCustomProvider = Object.values(working.value.providers).find(item => (
     item.custom && (!item.name?.trim() || !item.base_url?.trim() || !(item.models ?? []).length)
   ))
   if (incompleteCustomProvider) {
     if (!incompleteCustomProvider.name?.trim()) {
       notice.value = { tone: 'error', text: '请填写中转站名称。' }
-      return
+      return false
     }
     if (!incompleteCustomProvider.base_url?.trim()) {
       notice.value = { tone: 'error', text: '请填写 API 端点（Base URL）。' }
-      return
+      return false
     }
     if (!(incompleteCustomProvider.models ?? []).length) {
       notice.value = { tone: 'error', text: '请至少添加一个模型 ID 或关键词前缀。' }
-      return
+      return false
     }
   }
   saving.value = true
@@ -988,7 +984,7 @@ async function save() {
         tone: 'ok',
         text: category.value === 'coding' ? 'Skills 设置已保存。' : '设置已保存。',
       }
-      return
+      return true
     }
     // Only probe when the active service can actually start (enabled + key).
     const active = working.value.providers[working.value.active_provider]
@@ -1003,7 +999,7 @@ async function save() {
         tone: 'ok',
         text: '设置已保存。当前没有已启用且可用的模型服务，请启用账户或填写 TokenFlux / 自定义中转站后再验证。',
       }
-      return
+      return true
     }
     verifying.value = true
     try {
@@ -1016,6 +1012,7 @@ async function save() {
         tone: 'ok',
         text: `已保存并验证 ${result.provider}/${result.model}，PI 响应 ${result.latencyMs} ms。`,
       }
+      return true
     } catch (reason) {
       await refreshCallableModels()
       const raw = String(reason)
@@ -1023,6 +1020,7 @@ async function save() {
         ? '凭据已保存，但当前没有可用的账户或个人模型来源。请启用 MilkSU 账户或 TokenFlux 个人 Key 后重试。'
         : `凭据已保存，但 PI 模型验证失败：${raw}`
       notice.value = { tone: 'error', text: friendly }
+      return true
     } finally {
       verifying.value = false
     }
@@ -1041,6 +1039,7 @@ async function save() {
     notice.value = { tone: 'error', text: sessionOnly
       ? `${String(reason)} 当前密钥仅保留在本次运行内，退出应用后需要重新输入。`
       : `设置未保存：${String(reason)}` }
+    return false
   } finally {
     saving.value = false
   }
@@ -1051,8 +1050,12 @@ async function saveProviderEditor(closeAfterSave: boolean) {
     await save()
     return
   }
-  // Probe the service being edited, not a stale active_provider from old official keys.
   const editingID = editingProviderID.value
+  const pending = pendingCustomRelay.value?.id === editingID ? pendingCustomRelay.value : null
+  if (pending) {
+    working.value.providers[pending.id] = pending.config
+  }
+  // Probe the service being edited, not a stale active_provider from old official keys.
   const editing = working.value.providers[editingID]
   if (editing && (editing.has_api_key || String(editing.api_key ?? '').trim() || editingID === 'tokenflux')) {
     working.value.active_provider = editingID
@@ -1070,11 +1073,19 @@ async function saveProviderEditor(closeAfterSave: boolean) {
       }
     }
   }
-  await save()
+  const persisted = await save()
   // Catalog refresh happens inside save(); re-align default model to new list.
   alignDefaultModelToEnabledServices()
-  if (closeAfterSave && notice.value?.tone === 'ok') {
-    providerEditorOpen.value = false
+  if (persisted) {
+    pendingCustomRelay.value = null
+    if (closeAfterSave && notice.value?.tone === 'ok') {
+      providerEditorOpen.value = false
+    }
+    return
+  }
+  if (pending) {
+    delete working.value.providers[pending.id]
+    pendingCustomRelay.value = pending
   }
 }
 

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -45,7 +45,7 @@
 - 账户模型目录按账户凭据优先刷新并记录不含密钥的 `credential_source`；权威账户目录缺少所选模型时，请求前跳过账户来源，目录未知时仍保留运行时尝试。TokenFlux 在首个内容输出前返回 `model_not_found` / `not supported by any configured account` 时，可安全回退到已配置的个人来源；设置页默认模型与 Coding 共用同一可调用目录。
 - 图片按当前模型能力路由：模型声明 image input 时原图进入同一 Pi 回合，否则使用本地 OCR；不配置第二个视觉模型。选择、粘贴和拖放的普通文件进入统一附件栏，可排序、预览、移除并以 Pi 附件描述发送。
 - Coding 网页查证复用固定 revision 的 Pi `web_search` / `web_fetch` Extension，不另建 MilkSU 搜索决策状态机；真实联网查询已完成搜索并读取 xAI 官方文档。
-- 设置页支持账户模型、原厂 Provider 和最多 8 个简单 OpenAI-compatible 中转站；Key 统一进入 Credential Store，未配置来源不进入模型列表。
+- 设置页支持账户模型、原厂 Provider 和最多 8 个简单 OpenAI-compatible 中转站；Key 统一进入 Credential Store，未配置来源不进入模型列表。新增中转站只在编辑对话框保存成功后进入列表；MilkSU 账户与自定义中转并列，不因当前默认是中转而隐藏账户行。
 
 ### 桌面产品表面
 


### PR DESCRIPTION
此PR修复了三个问题
1. [设置 > 通用 > 数据库兼容性] 现在具有正确的margin。
    修复前：
    <img width="843" height="736" alt="ecf79026dbc735e84657312578e5e7d8" src="https://github.com/user-attachments/assets/7d045185-ce6e-488d-89de-dabd95a087bc" />
    修复后：
    <img width="795" height="518" alt="image" src="https://github.com/user-attachments/assets/2b3f3ab1-e7f4-4746-8403-3130557a643f" />
2. [设置 > 模型] 现在会在保存后才添加提供商，而非点击+后立即添加。
3. [设置 > 模型] 已修复点击+后MilkSU账户消失，保存后又重新显示的问题，现在MilkSU账户会一直显示。