### PR TITLE
fix(ctf): serve collection views from the local catalog

### DIFF
--- a/app/src/components-vue/CTFPage.vue
+++ b/app/src/components-vue/CTFPage.vue
@@ -226,6 +226,18 @@ const dailyChallengeVisible = computed(() => (
     ? dailyChallenge.value
     : null
 ))
+
+// A selected problem only belongs to a filtered collection view when it is
+// actually in that collection; otherwise the daily challenge or a stale
+// recommendation could keep showing in an unrelated (even empty) view.
+const visibleSelectedNssctf = computed(() => {
+  const selected = selectedProblem.value
+  if (!selected) return null
+  if (collectionView.value === ALL_COLLECTIONS_ID) return selected
+  return ctfCollections.has(`nssctf:${selected.platformId}`, collectionView.value)
+    ? selected
+    : null
+})
 const catalogErrorMessage = computed(() => {
   const error = activeBank.value === 'nssctf'
     ? publicCatalog.error.value ?? training.error.value
@@ -796,12 +808,18 @@ watch(ctfshowPageCount, pageCount => {
   if (ctfshowPage.value > pageCount) ctfshowPage.value = pageCount
 })
 
-watch([catalogQuery, catalogCategory, collectionView, ctfCollections.revision], () => {
+watch([catalogQuery, catalogCategory], () => {
   if (activeBank.value !== 'nssctf' || screen.value !== 'challenge') return
   if (catalogSearchTimer) clearTimeout(catalogSearchTimer)
   catalogSearchTimer = setTimeout(() => {
     void loadPublicCatalog(1)
   }, 220)
+})
+
+watch([collectionView, ctfCollections.revision], () => {
+  if (activeBank.value !== 'nssctf' || screen.value !== 'challenge') return
+  selectedProblem.value = null
+  void loadPublicCatalog(1)
 })
 
 watch(
@@ -923,7 +941,8 @@ async function selectDefaultDeskProblem() {
     return
   }
   if (selectedProblem.value) return
-  const recommendation = catalogQuery.value.trim() === '' && catalogCategory.value === 'all'
+  const recommendation = collectionView.value === ALL_COLLECTIONS_ID
+    && catalogQuery.value.trim() === '' && catalogCategory.value === 'all'
     ? training.dashboard.value?.recommendations[0]
     : null
   const platformId = dailyChallengeVisible.value?.platformId
@@ -1636,6 +1655,7 @@ function refreshBridgePresence() {
 
 onMounted(async () => {
   document.addEventListener('pointerdown', closeHistoryMenuOnOutsidePointer)
+  void publicCatalog.ensureLoaded()
   await Promise.all([
     webBridge.refresh(),
     training.load(),
@@ -2432,7 +2452,7 @@ onBeforeUnmount(() => {
           :active-bank="activeCatalogBank"
           :nssctf-problems="publicCatalog.result.value?.problems ?? []"
           :ctfshow-problems="visibleCTFShowProblems"
-          :selected-nssctf="selectedProblem"
+          :selected-nssctf="visibleSelectedNssctf"
           :daily-problem="dailyChallengeVisible"
           :daily-reason="dailyChallengeReason"
           :selected-ctfshow="selectedCTFShowProblem"

--- a/app/src/composables/useNSSCTFTraining.test.ts
+++ b/app/src/composables/useNSSCTFTraining.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import type { NSSCTFCatalogSearchResult } from '@/nssctfTrainingTypes'
+
+const { invokeCommand } = vi.hoisted(() => ({
+  invokeCommand: vi.fn(),
+}))
+
+vi.mock('@/desktop', () => ({
+  invokeCommand,
+}))
+
+function problem(platformId: number) {
+  return {
+    platformId,
+    sourceUrl: `https://www.nssctf.cn/problem/${platformId}`,
+    title: `题目 ${platformId}`,
+    category: 'Web',
+    points: 100,
+    difficulty: 1,
+    tags: [],
+    hasWriteup: false,
+    solvedCount: 0,
+    wrongAnswerCount: 0,
+    noAnswerCount: 0,
+    open: true,
+    syncedAt: '2026-08-17T00:00:00Z',
+  }
+}
+
+function result(platformId: number): NSSCTFCatalogSearchResult {
+  return {
+    problems: [problem(platformId)],
+    categories: ['Web'],
+    attemptedProblemIds: [],
+    completedProblemIds: [],
+    total: 1,
+    page: 1,
+    pageSize: 20,
+    pageCount: 1,
+  }
+}
+
+function fullCatalogResult(platformIds: number[], categories: string[] = ['Web']): NSSCTFCatalogSearchResult {
+  return {
+    problems: platformIds.map(problem),
+    categories,
+    attemptedProblemIds: [],
+    completedProblemIds: [],
+    total: platformIds.length,
+    page: 1,
+    pageSize: 0,
+    pageCount: 1,
+  }
+}
+
+const makeQuery = (value: string) => ({
+  query: value,
+  category: 'all',
+  page: 1,
+  pageSize: 20 as const,
+})
+
+describe('useNSSCTFCatalog', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    invokeCommand.mockReset()
+  })
+
+  async function freshModule() {
+    return import('./useNSSCTFTraining')
+  }
+
+  it('returns cached results without issuing another desktop query', async () => {
+    const first = result(101)
+    invokeCommand.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === 'list_nssctf_catalog') {
+        const query = (args as { query: { pageSize: number } }).query
+        if (query.pageSize === 0) return fullCatalogResult([101])
+        return first
+      }
+      throw new Error(`unexpected command: ${command}`)
+    })
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+
+    await catalog.search(makeQuery('收藏'))
+    await catalog.search(makeQuery('收藏'))
+
+    expect(invokeCommand).toHaveBeenCalledOnce()
+    expect(catalog.result.value?.problems[0]?.platformId).toBe(101)
+  })
+
+  it('keeps the visible result while a new search query is pending', async () => {
+    const first = result(101)
+    let resolveNext!: (value: NSSCTFCatalogSearchResult) => void
+    invokeCommand
+      .mockImplementationOnce(() => Promise.resolve(first))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveNext = resolve }))
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+
+    await catalog.search(makeQuery('web'))
+    const pending = catalog.search(makeQuery('sql'))
+    await nextTick()
+
+    expect(catalog.result.value?.problems[0]?.platformId).toBe(101)
+    expect(catalog.loading.value).toBe(true)
+
+    resolveNext(result(202))
+    await pending
+    expect(catalog.result.value?.problems[0]?.platformId).toBe(202)
+  })
+
+  it('does not let an older response replace the latest filter result', async () => {
+    let resolveOld!: (value: NSSCTFCatalogSearchResult) => void
+    let resolveCurrent!: (value: NSSCTFCatalogSearchResult) => void
+    invokeCommand
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOld = resolve }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveCurrent = resolve }))
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+
+    const oldRequest = catalog.search(makeQuery('旧'))
+    const currentRequest = catalog.search(makeQuery('当前'))
+    resolveCurrent(result(303))
+    await currentRequest
+    resolveOld(result(404))
+    await oldRequest
+
+    expect(catalog.result.value?.problems[0]?.platformId).toBe(303)
+  })
+
+  it('serves collection filter switches from the local full catalog without RPC', async () => {
+    const full = fullCatalogResult([101, 202, 303, 404])
+    invokeCommand.mockImplementation(async (command: string) => {
+      if (command === 'list_nssctf_catalog') return full
+      throw new Error(`unexpected command: ${command}`)
+    })
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+
+    await catalog.ensureLoaded()
+    invokeCommand.mockClear()
+
+    const result = await catalog.search({ query: '', category: 'all', page: 1, pageSize: 20, problemIds: [303, 101] })
+    expect(result?.problems.map(item => item.platformId).sort()).toEqual([101, 303])
+    expect(invokeCommand).not.toHaveBeenCalled()
+    expect(catalog.loading.value).toBe(false)
+  })
+
+  it('pages locally when a collection has more problems than one page', async () => {
+    const full = fullCatalogResult([...Array.from({ length: 25 }, (_, index) => 1000 + index)])
+    invokeCommand.mockImplementation(async (command: string) => {
+      if (command === 'list_nssctf_catalog') return full
+      throw new Error(`unexpected command: ${command}`)
+    })
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+    await catalog.ensureLoaded()
+    invokeCommand.mockClear()
+
+    const pageOne = await catalog.search({ query: '', category: 'all', page: 1, pageSize: 20, problemIds: undefined })
+    const pageTwo = await catalog.search({ query: '', category: 'all', page: 2, pageSize: 20, problemIds: undefined })
+    expect(pageOne?.problems).toHaveLength(20)
+    expect(pageOne?.total).toBe(25)
+    expect(pageOne?.pageCount).toBe(2)
+    expect(pageTwo?.problems).toHaveLength(5)
+    expect(invokeCommand).not.toHaveBeenCalled()
+  })
+
+  it('still queries the backend for keyword search', async () => {
+    const full = fullCatalogResult([101])
+    const searched = fullCatalogResult([101], [])
+    invokeCommand.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === 'list_nssctf_catalog') {
+        const query = (args as { query: { pageSize: number } }).query
+        if (query.pageSize === 0) return full
+        return searched
+      }
+      throw new Error(`unexpected command: ${command}`)
+    })
+    const catalog = (await freshModule()).useNSSCTFCatalog()
+    await catalog.ensureLoaded()
+    invokeCommand.mockClear()
+
+    const result = await catalog.search({ query: 'web', category: 'all', page: 1, pageSize: 20 })
+    expect(result?.problems.map(item => item.platformId)).toEqual([101])
+    expect(invokeCommand).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/composables/useNSSCTFTraining.ts
+++ b/app/src/composables/useNSSCTFTraining.ts
@@ -13,6 +13,62 @@ const dashboard = ref<NSSCTFTrainingDashboard | null>(null)
 const dashboardLoading = ref(false)
 const dashboardSyncing = ref(false)
 const dashboardError = ref<string | null>(null)
+const catalogSearchCache = new Map<string, NSSCTFCatalogSearchResult>()
+const fullCatalog = ref<NSSCTFCatalogSearchResult | null>(null)
+const fullCatalogLoading = ref(false)
+
+function catalogSearchKey(query: NSSCTFCatalogQuery) {
+  return JSON.stringify({
+    query: query.query.trim(),
+    category: query.category,
+    page: query.page,
+    pageSize: query.pageSize,
+    problemIds: query.problemIds ? [...query.problemIds].sort((left, right) => left - right) : undefined,
+  })
+}
+
+function isLocalCatalogQuery(query: NSSCTFCatalogQuery) {
+  return query.query.trim() === '' && (query.category === '' || query.category === 'all')
+}
+
+async function loadFullCatalog() {
+  if (fullCatalog.value || fullCatalogLoading.value) return fullCatalog.value
+  fullCatalogLoading.value = true
+  try {
+    const result = await invokeCommand<NSSCTFCatalogSearchResult>('list_nssctf_catalog', {
+      query: { query: '', category: 'all', page: 1, pageSize: 0 },
+    })
+    fullCatalog.value = result
+    clearCatalogSearchCache()
+    return result
+  } finally {
+    fullCatalogLoading.value = false
+  }
+}
+
+function applyLocalCatalogSearch(query: NSSCTFCatalogQuery, full: NSSCTFCatalogSearchResult) {
+  const wanted = new Set(query.problemIds ?? [])
+  const filtered = query.problemIds
+    ? full.problems.filter(problem => wanted.has(problem.platformId))
+    : full.problems
+  const pageSize = query.pageSize || 20
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const page = Math.min(Math.max(1, query.page), pageCount)
+  return {
+    problems: filtered.slice((page - 1) * pageSize, page * pageSize),
+    categories: full.categories,
+    attemptedProblemIds: full.attemptedProblemIds,
+    completedProblemIds: full.completedProblemIds,
+    total: filtered.length,
+    page,
+    pageSize,
+    pageCount,
+  }
+}
+
+function clearCatalogSearchCache() {
+  catalogSearchCache.clear()
+}
 
 export function useNSSCTFTraining() {
   async function load() {
@@ -35,6 +91,9 @@ export function useNSSCTFTraining() {
       const result = await invokeCommand<NSSCTFCatalogSyncResult>('sync_nssctf_catalog', {
         url: CATALOG_URL,
       })
+      clearCatalogSearchCache()
+      fullCatalog.value = null
+      void loadFullCatalog()
       await load()
       dashboardError.value = null
       return result
@@ -60,22 +119,48 @@ export function useNSSCTFCatalog() {
   const result = ref<NSSCTFCatalogSearchResult | null>(null)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  let requestGeneration = 0
 
   async function search(query: NSSCTFCatalogQuery) {
+    const generation = ++requestGeneration
+    const locallyServiceable = isLocalCatalogQuery(query)
+    const full = locallyServiceable ? fullCatalog.value : null
+    if (full) {
+      result.value = applyLocalCatalogSearch(query, full)
+      error.value = null
+      loading.value = false
+      return result.value
+    }
+    const key = catalogSearchKey(query)
+    const cached = catalogSearchCache.get(key)
+    if (cached) {
+      result.value = cached
+      error.value = null
+      loading.value = false
+      return cached
+    }
+
     loading.value = true
+    if (locallyServiceable) void loadFullCatalog()
     try {
-      result.value = await invokeCommand<NSSCTFCatalogSearchResult>('list_nssctf_catalog', {
+      const next = await invokeCommand<NSSCTFCatalogSearchResult>('list_nssctf_catalog', {
         query,
       })
-      error.value = null
-      return result.value
+      catalogSearchCache.set(key, next)
+      if (generation === requestGeneration) {
+        result.value = next
+        error.value = null
+      }
+      return next
     } catch (reason) {
-      error.value = reason instanceof Error ? reason.message : String(reason)
+      if (generation === requestGeneration) {
+        error.value = reason instanceof Error ? reason.message : String(reason)
+      }
       return null
     } finally {
-      loading.value = false
+      if (generation === requestGeneration) loading.value = false
     }
   }
 
-  return { result, loading, error, search }
+  return { result, loading, error, search, ensureLoaded: loadFullCatalog }
 }

--- a/app/src/nssctfTrainingTypes.ts
+++ b/app/src/nssctfTrainingTypes.ts
@@ -25,7 +25,7 @@ export interface NSSCTFCatalogQuery {
   query: string
   category: string
   page: number
-  pageSize: 10 | 20 | 40
+  pageSize: 0 | 10 | 20 | 40
   problemIds?: number[]
 }
 

--- a/internal/nssctf/catalog.go
+++ b/internal/nssctf/catalog.go
@@ -672,8 +672,12 @@ func (s *CatalogService) Search(ctx context.Context, request CatalogQuery) (Cata
 		page = 1
 	}
 	pageSize := request.PageSize
-	if pageSize != 10 && pageSize != 20 && pageSize != 40 {
+	if pageSize < 0 || (pageSize != 0 && pageSize != 10 && pageSize != 20 && pageSize != 40) {
 		pageSize = 20
+	}
+	all := pageSize == 0
+	if all {
+		page = 1
 	}
 
 	where := []string{"is_open = 1"}
@@ -740,7 +744,11 @@ func (s *CatalogService) Search(ctx context.Context, request CatalogQuery) (Cata
 	}
 	pageCount := 0
 	if total > 0 {
-		pageCount = int(math.Ceil(float64(total) / float64(pageSize)))
+		if all {
+			pageCount = 1
+		} else {
+			pageCount = int(math.Ceil(float64(total) / float64(pageSize)))
+		}
 		if page > pageCount {
 			page = pageCount
 		}
@@ -749,6 +757,11 @@ func (s *CatalogService) Search(ctx context.Context, request CatalogQuery) (Cata
 	}
 
 	searchArgs := append(append(append([]any{}, args...), orderArgs...), pageSize, (page-1)*pageSize)
+	if all {
+		// SQLite treats a negative LIMIT as "no limit", used for the local full-catalog load.
+		searchArgs[len(searchArgs)-2] = -1
+		searchArgs[len(searchArgs)-1] = 0
+	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT platform_id, source_url, title, category, points, difficulty, tags_json,
 			has_writeup, solved_count, wrong_answer_count, no_answer_count, is_open, synced_at


### PR DESCRIPTION
## 功能背景

CTF 题库的“全部 / 收藏”切换此前会在每次操作时通过 Desktop RPC 重新查询 SQLite。即使用户已经访问过对应视图，界面仍需等待后端响应，产生约一秒的切换停顿。快速连续切换时，较早的请求还可能晚于新请求返回并覆盖当前结果。

收藏视图还可能继续显示每日挑战、推荐题目或切换前选中的题目，即使这些题目并不属于当前收藏集合。

## 功能实现

- 首次进入 NSSCTF 题库时，在后台加载一次完整的本地目录并保存在前端会话内存中。
- “全部 / 收藏”集合切换直接基于完整本地目录筛选和分页，不再为每次切换调用 Desktop RPC。
- 关键词和分类搜索仍交给后端查询，避免把完整搜索语义复制到前端。
- 相同查询结果使用内存缓存；题库同步成功后清空缓存并重新预热完整目录。
- 新查询等待期间保留当前可见列表，避免切换时闪空。
- 使用请求代际保护，较旧响应不能覆盖用户最新选择的筛选结果。
- 收藏题目超过一页时，在本地结果中正确计算页数并分页。
- 切换集合时清理旧选中题目；只有属于当前集合的题目才能继续显示。
- 每日挑战和推荐题目只在“全部”视图参与默认题目选择，不再混入收藏视图。
- 后端目录查询增加 `pageSize: 0` 的受控语义，用于一次性读取完整本地开放题目目录；普通分页仍只接受现有的 10、20、40 条规格。

## 用户影响

- 已加载题库后，“全部 / 收藏”切换可即时响应。
- 收藏视图不会显示未收藏的每日挑战、推荐题目或陈旧选中题目。
- 快速连续切换不会被较早请求回写成错误列表。
- 关键词搜索、分类筛选和题库同步行为保持原有后端语义。

## 改动范围

本 PR 只包含 CTF 目录集合视图修复，共修改 5 个文件：

- `app/src/components-vue/CTFPage.vue`
- `app/src/composables/useNSSCTFTraining.ts`
- `app/src/composables/useNSSCTFTraining.test.ts`
- `app/src/nssctfTrainingTypes.ts`
- `internal/nssctf/catalog.go`

不包含应用级调试模式、设置页改动、fork 文档、Windows 测试兼容修复或无关格式化。

## 验证结果

已通过：

- CTF 定向前端测试：3 个测试文件、23 个测试全部通过。
- 新增目录缓存与切换测试：6 个测试全部通过。
- `npm run lint`：通过。
- `npm run build`：`vue-tsc -b` 与 Vite 生产构建通过。
- `go test ./internal/nssctf -count=1`：通过。
- `git diff --cached --check`：通过，无冲突标记或空白错误。

Windows 本地运行全量前端测试时为 463 / 466 通过。剩余 3 项是 `official/main` 现有源码文本契约测试把换行写死为 LF，在 CRLF 工作树上失败：

- `globalStyleContract.test.ts`：2 项。
- `WorkspaceTopBar.test.ts`：1 项。

这些失败可在未应用本功能的 `official/main` 上复现，与本 PR 无关；对应 Windows 换行兼容修复应作为独立 PR，不混入本功能提交。