### PR TITLE
test(app): normalize raw source line endings on Windows

### DIFF
--- a/app/src/components-vue/WorkspaceTopBar.test.ts
+++ b/app/src/components-vue/WorkspaceTopBar.test.ts
@@ -2,10 +2,10 @@
 
 import { createApp, nextTick, type App } from 'vue'
 import { afterEach, describe, expect, it } from 'vitest'
-import chatPageSource from './ChatPage.vue?raw'
+import chatPageSourceRaw from './ChatPage.vue?raw'
 import ctfEndpointAuthorizationSource from './CTFEndpointAuthorization.vue?raw'
 import ctfManualIntakeSource from './CTFManualIntake.vue?raw'
-import ctfPageSource from './CTFPage.vue?raw'
+import ctfPageSourceRaw from './CTFPage.vue?raw'
 import ctfWorkspaceHeaderSource from './CTFWorkspaceHeader.vue?raw'
 import vulnPageSource from './VulnPage.vue?raw'
 import WorkspaceModuleTopBar from './WorkspaceModuleTopBar.vue'
@@ -13,6 +13,9 @@ import workspaceModuleTopBarSource from './WorkspaceModuleTopBar.vue?raw'
 import workspaceTopBarSource from './WorkspaceTopBar.vue?raw'
 import WorkspaceTopBar from './WorkspaceTopBar.vue'
 import workspaceTopBarTitleSource from './WorkspaceTopBarTitle.vue?raw'
+
+const chatPageSource = chatPageSourceRaw.replaceAll('\r\n', '\n')
+const ctfPageSource = ctfPageSourceRaw.replaceAll('\r\n', '\n')
 
 const mountedApps: App[] = []
 

--- a/app/src/globalStyleContract.test.ts
+++ b/app/src/globalStyleContract.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-const indexCss = readFileSync(fileURLToPath(new URL('./index.css', import.meta.url)), 'utf8')
+const indexCss = readFileSync(fileURLToPath(new URL('./index.css', import.meta.url)), 'utf8').replaceAll('\r\n', '\n')
 
 describe('global style contract', () => {
   it('keeps compact form controls on one shared font scale', () => {


### PR DESCRIPTION
## 问题背景

`official/main` 新增的部分 UI 源码契约测试会直接读取 Vue/CSS 源文件，并用包含 `\n` 的多行字符串检查组件结构和样式规则。

在 Windows 的 `core.autocrlf=true` 工作树中，这些源文件使用 CRLF（`\r\n`）。产品源码内容没有变化，但测试读取到的换行符与断言中的 LF 不一致，导致以下 3 项测试稳定失败：

- `globalStyleContract.test.ts`：2 项。
- `WorkspaceTopBar.test.ts`：1 项。

## 修复实现

- 将 `ChatPage.vue?raw` 和 `CTFPage.vue?raw` 的测试输入在断言前统一从 CRLF 标准化为 LF。
- 将 `index.css` 的读取结果在断言前统一从 CRLF 标准化为 LF。
- 保留所有原有源码文本断言，不修改预期组件结构、样式选择器或视觉契约。
- 不修改任何 Vue、CSS 或生产代码。
- 不引入 `.gitattributes` 全仓换行策略，避免为了测试改变开发者工作树和无关文件。

## 改动范围

本 PR 只修改 2 个测试文件：

- `app/src/components-vue/WorkspaceTopBar.test.ts`
- `app/src/globalStyleContract.test.ts`

共 6 行新增、3 行修改，不包含产品功能或格式化改动。

## 验证结果

已在 Windows 环境完成验证：

- `npm test`：73 个测试文件、460 个测试全部通过。
- `npm run lint`：通过。
- `npm run build`：`vue-tsc -b` 与 Vite 生产构建通过。
- `git diff --cached --check`：通过。

该修复只标准化测试输入的换行符，不降低或跳过任何 UI 源码契约断言。