### PR TITLE
feat(debug): add an application-wide local debug mode

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -15,6 +15,7 @@ import {
 } from '@/lib/themeMode'
 import { settingsReturnSection, type CTFWorkspaceSection } from '@/lib/workspaceNavigation'
 import { executeVulnerabilityCodingHandoff } from '@/lib/vulnerabilityCodingHandoff'
+import { debugLog } from '@/lib/debugMode'
 import { buildCTFDomainTaskContext } from '@/lib/domainTaskContext'
 import {
   rememberWorkspaceConversation,
@@ -271,6 +272,7 @@ function restoreCTFWorkspaceResumePoint() {
 }
 
 function navigateSection(value: Section) {
+  debugLog('section', value)
   rememberActiveConversation()
   if (value === 'ctf') {
     restoreCTFWorkspaceResumePoint()

--- a/app/src/components-vue/CTFPage.vue
+++ b/app/src/components-vue/CTFPage.vue
@@ -81,6 +81,7 @@ import {
   parseCTFDailyChallengeRecord,
 } from '@/lib/ctfDailyChallenge'
 import { ALL_COLLECTIONS_ID, createItemCollectionStore } from '@/lib/itemCollections'
+import { debugLog, updateDebugState } from '@/lib/debugMode'
 import {
   ctfManualStatusFromJobStatus,
   ctfManualStatusLabel,
@@ -819,6 +820,11 @@ watch([catalogQuery, catalogCategory], () => {
 watch(collectionView, () => {
   if (activeBank.value !== 'nssctf' || screen.value !== 'challenge') return
   selectedProblem.value = null
+  debugLog('switch-collection', `view=${collectionView.value}`)
+  updateDebugState({
+    view: collectionView.value,
+    selectedPlatformId: null,
+  })
   void loadPublicCatalog(1).then(() => selectDefaultDeskProblem())
 })
 
@@ -937,12 +943,19 @@ async function loadPublicCatalog(page = catalogPage.value) {
         .filter(key => key.startsWith('nssctf:'))
         .map(key => Number(key.slice('nssctf:'.length)))
         .filter(Number.isFinite)
+  const started = Date.now()
   const result = await publicCatalog.search({
     query: catalogQuery.value,
     category: catalogCategory.value,
     page,
     pageSize: catalogPageSize,
     problemIds,
+  })
+  debugLog('load-catalog', `page=${page} view=${collectionView.value}`, Date.now() - started)
+  updateDebugState({
+    view: collectionView.value,
+    selectedPlatformId: selectedProblem.value?.platformId ?? null,
+    collectionProblems: problemIds ? problemIds.length : 0,
   })
   if (result) catalogPage.value = result.page
 }

--- a/app/src/components-vue/SettingsPage.vue
+++ b/app/src/components-vue/SettingsPage.vue
@@ -91,6 +91,7 @@ import ModelVendorIcon from '@/components-vue/ModelVendorIcon.vue'
 import type { SecurityToolCodingHandoff } from '@/securityToolsTypes'
 import { useVulnerabilityDashboard, type VulnerabilityDashboard } from '@/composables/useVulnerabilityDashboard'
 import { CODING_SKILLS } from '@/codingSkills'
+import { buildDiagnosticText, isDebugMode, setDebugMode } from '@/lib/debugMode'
 
 type SettingsCategory = 'general' | 'apikeys' | 'ctf' | 'cve' | 'coding' | 'browser' | 'security-tools'
 
@@ -693,6 +694,23 @@ function formatBuildTrackingText(tracking: BuildTracking) {
   return lines.join('\n')
 }
 
+const debugModeOn = ref(isDebugMode())
+
+async function copyDebugDiagnostics() {
+  const text = buildDiagnosticText()
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+  } else {
+    const area = document.createElement('textarea')
+    area.value = text
+    document.body.append(area)
+    area.select()
+    document.execCommand('copy')
+    area.remove()
+  }
+  notice.value = { tone: 'ok', text: '调试诊断已复制到剪贴板。' }
+}
+
 async function copyBuildTracking() {
   if (!buildTracking.value) return
   buildTrackingCopying.value = true
@@ -1122,6 +1140,22 @@ async function saveProviderEditor(closeAfterSave: boolean) {
         </Alert>
 
         <template v-if="working && category === 'general'">
+          <SettingsSection title="调试">
+            <SettingsRow
+              stack="always"
+              label="调试模式"
+              description="开启后在本机记录应用操作日志与状态（RPC 命令、页面切换、CTF 详情），用于排查偶发问题。日志不出设备，不含 API 密钥等信息。"
+            >
+              <Switch
+                :model-value="debugModeOn"
+                :aria-label="'开启调试模式'"
+                @update:model-value="value => { debugModeOn = value; setDebugMode(Boolean(value)) }"
+              />
+            </SettingsRow>
+            <div v-if="debugModeOn" class="mt-3">
+              <Button variant="outline" size="sm" @click="copyDebugDiagnostics">复制诊断</Button>
+            </div>
+          </SettingsSection>
           <SettingsSection title="账户">
             <SettingsRow
               label="GitHub 账户"

--- a/app/src/composables/useNSSCTFTraining.ts
+++ b/app/src/composables/useNSSCTFTraining.ts
@@ -1,5 +1,11 @@
 import { ref } from 'vue'
 import { invokeCommand } from '@/desktop'
+import {
+  debugLog,
+  recordCacheHit,
+  recordLocalHit,
+  updateDebugState,
+} from '@/lib/debugMode'
 import type {
   NSSCTFCatalogQuery,
   NSSCTFCatalogSearchResult,
@@ -73,6 +79,7 @@ async function loadFullCatalog() {
   if (fullCatalogLoad) return fullCatalogLoad
 
   const generation = fullCatalogGeneration
+  const started = Date.now()
   const pending = (async (): Promise<NSSCTFCatalogSearchResult | null> => {
     try {
       const result = await invokeCommand<NSSCTFCatalogSearchResult>('list_nssctf_catalog', {
@@ -84,6 +91,11 @@ async function loadFullCatalog() {
       fullCatalog.value = result
       rememberProgress(result)
       clearCatalogSearchCache()
+      updateDebugState({
+        fullCatalogReady: true,
+        fullCatalogProblems: result.problems.length,
+      })
+      debugLog('full-catalog-loaded', `${result.problems.length} problems`, Date.now() - started)
       return result
     } catch {
       if (generation !== fullCatalogGeneration) {
@@ -103,6 +115,7 @@ async function loadFullCatalog() {
 
 async function refreshTrainingProgressSnapshot() {
   const generation = fullCatalogGeneration
+  const started = Date.now()
   try {
     const result = await invokeCommand<NSSCTFCatalogSearchResult>('list_nssctf_catalog', {
       query: FULL_CATALOG_QUERY,
@@ -116,6 +129,11 @@ async function refreshTrainingProgressSnapshot() {
         completedProblemIds: result.completedProblemIds,
       }
     }
+    updateDebugState({
+      fullCatalogReady: Boolean(fullCatalog.value),
+      fullCatalogProblems: fullCatalog.value?.problems.length ?? result.problems.length,
+    })
+    debugLog('training-progress-refreshed', `${result.completedProblemIds.length} completed`, Date.now() - started)
     return trainingProgress.value
   } catch {
     return trainingProgress.value
@@ -202,10 +220,18 @@ export function useNSSCTFCatalog() {
     const locallyServiceable = isLocalCatalogQuery(query)
     const full = locallyServiceable ? fullCatalog.value : null
     if (full) {
-      result.value = applyLocalCatalogSearch(query, full)
+      const next = applyLocalCatalogSearch(query, full)
+      result.value = next
       error.value = null
       loading.value = false
-      return result.value
+      recordLocalHit()
+      updateDebugState({
+        fullCatalogReady: true,
+        fullCatalogProblems: full.problems.length,
+        collectionProblems: next.total,
+      })
+      debugLog('catalog-search', `local view=${query.problemIds ? 'collection' : 'all'} ${next.total} visible`)
+      return next
     }
     const key = catalogSearchKey(query)
     const cached = catalogSearchCache.get(key)
@@ -213,6 +239,8 @@ export function useNSSCTFCatalog() {
       result.value = withCurrentProgress(cached)
       error.value = null
       loading.value = false
+      recordCacheHit()
+      debugLog('catalog-search', 'cache hit')
       return result.value
     }
 

--- a/app/src/desktop.test.ts
+++ b/app/src/desktop.test.ts
@@ -3,14 +3,38 @@
 import { reactive } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { invokeCommand } from './desktop'
+import {
+  buildDiagnosticText,
+  debugLogEntries,
+  setDebugMode,
+} from './lib/debugMode'
 
 afterEach(() => {
+  setDebugMode(false)
   vi.restoreAllMocks()
   Reflect.deleteProperty(window, 'go')
   Reflect.deleteProperty(window, 'milksu')
 })
 
 describe('desktop command adapter', () => {
+  it('records each RPC invocation once in the local debug snapshot', async () => {
+    setDebugMode(true)
+    const invoke = vi.fn(async () => undefined)
+    Object.defineProperty(window, 'milksu', {
+      configurable: true,
+      value: { invoke },
+    })
+
+    await invokeCommand('list_nssctf_catalog', { query: { page: 1 } })
+    await invokeCommand('get_settings')
+
+    expect(debugLogEntries().map(entry => [entry.action, entry.detail])).toEqual([
+      ['rpc', 'list_nssctf_catalog'],
+      ['rpc', 'get_settings'],
+    ])
+    expect(buildDiagnosticText()).toContain('rpc calls: 2')
+  })
+
   it('imports and previews renderer clipboard attachments through Desktop RPC', async () => {
     const attachment = {
       id: 'a'.repeat(64),

--- a/app/src/desktop.ts
+++ b/app/src/desktop.ts
@@ -1,3 +1,4 @@
+import { recordRpcCall } from '@/lib/debugMode'
 import {
   type AccountStatus,
   type AppSettings,
@@ -446,6 +447,7 @@ export function hasDesktopRuntime(): boolean {
 }
 
 export async function invokeCommand<T = unknown>(command: string, args?: CommandArgs): Promise<T> {
+  recordRpcCall(command)
   const app = getDesktopApp()
   if (!app) {
     throw new Error(`MilkSU desktop runtime is unavailable for command: ${command}`)

--- a/app/src/lib/debugMode.test.ts
+++ b/app/src/lib/debugMode.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEBUG_MODE_STORAGE_KEY,
+  buildDiagnosticText,
+  debugLog,
+  debugLogEntries,
+  isDebugMode,
+  recordCacheHit,
+  recordLocalHit,
+  recordRpcCall,
+  setDebugMode,
+  updateDebugState,
+} from './debugMode'
+
+describe('debugMode', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    window.localStorage.clear()
+    setDebugMode(false)
+  })
+
+  it('ignores logging while disabled', () => {
+    debugLog('switch', 'x')
+    recordRpcCall('list')
+    expect(debugLogEntries()).toHaveLength(0)
+  })
+
+  it('records entries and counts only while enabled', () => {
+    setDebugMode(true)
+    debugLog('switch-collection', 'all -> favorites', 12)
+    debugLog('search', 'local hit')
+    recordLocalHit()
+    recordCacheHit()
+    recordRpcCall('sync_nssctf_catalog')
+    updateDebugState({ view: 'favorites', selectedPlatformId: 42 })
+
+    const entries = debugLogEntries()
+    expect(entries.map(entry => entry.action)).toEqual(['switch-collection', 'search', 'rpc'])
+    expect(entries[0].durationMs).toBe(12)
+    expect(isDebugMode()).toBe(true)
+
+    const text = buildDiagnosticText()
+    expect(text).toContain('view: favorites')
+    expect(text).toContain('local hits: 1')
+    expect(text).toContain('cache hits: 1')
+    expect(text).toContain('rpc calls: 1')
+    expect(text).toContain('selected platform: 42')
+    expect(text).toContain('switch-collection')
+  })
+
+  it('persists the enabled flag across module reloads', async () => {
+    setDebugMode(true)
+    expect(window.localStorage.getItem(DEBUG_MODE_STORAGE_KEY)).toBe('1')
+    // reload module: flag is read back from storage on import
+    const reloaded = await import('./debugMode')
+    expect(reloaded.isDebugMode()).toBe(true)
+  })
+
+  it('clears logs and counters when disabled', () => {
+    setDebugMode(true)
+    debugLog('a')
+    recordLocalHit()
+    setDebugMode(false)
+    expect(debugLogEntries()).toHaveLength(0)
+    expect(buildDiagnosticText()).toContain('local hits: 0')
+  })
+})

--- a/app/src/lib/debugMode.ts
+++ b/app/src/lib/debugMode.ts
@@ -1,0 +1,123 @@
+// Local debug/logging mode for MilkSU. Enabled from the Settings page.
+// All diagnostics stay local: ring buffer in memory, optional snapshot
+// export to clipboard. No network egress. Fields that could carry
+// credentials or real user content are deliberately never collected here.
+
+export const DEBUG_MODE_STORAGE_KEY = 'milksu.debug-mode'
+
+export interface DebugLogEntry {
+  time: string
+  action: string
+  detail: string
+  durationMs: number
+}
+
+export interface DebugStateSnapshot {
+  view: string
+  bank: string
+  fullCatalogReady: boolean
+  fullCatalogProblems: number
+  collectionProblems: number
+  selectedPlatformId: number | null
+  localHits: number
+  rpcCalls: number
+  cacheHits: number
+}
+
+const MAX_LOG_ENTRIES = 200
+
+const log: DebugLogEntry[] = []
+const state: DebugStateSnapshot = {
+  view: '',
+  bank: 'nssctf',
+  fullCatalogReady: false,
+  fullCatalogProblems: 0,
+  collectionProblems: 0,
+  selectedPlatformId: null,
+  localHits: 0,
+  rpcCalls: 0,
+  cacheHits: 0,
+}
+
+function readDebugMode(): boolean {
+  try {
+    return window.localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+let enabled = readDebugMode()
+
+export function isDebugMode(): boolean {
+  return enabled
+}
+
+export function setDebugMode(value: boolean): void {
+  enabled = value
+  try {
+    window.localStorage.setItem(DEBUG_MODE_STORAGE_KEY, value ? '1' : '0')
+  } catch {
+    // storage unavailable; keep in-memory mode for this session
+  }
+  if (!value) {
+    log.length = 0
+    state.localHits = 0
+    state.rpcCalls = 0
+    state.cacheHits = 0
+  }
+}
+
+export function debugLog(action: string, detail = '', durationMs = -1): void {
+  if (!enabled) return
+  log.push({
+    time: new Date().toISOString(),
+    action,
+    detail,
+    durationMs,
+  })
+  if (log.length > MAX_LOG_ENTRIES) {
+    log.splice(0, log.length - MAX_LOG_ENTRIES)
+  }
+}
+
+export function updateDebugState(patch: Partial<DebugStateSnapshot>): void {
+  if (!enabled) return
+  Object.assign(state, patch)
+}
+
+export function recordLocalHit(): void {
+  if (enabled) state.localHits += 1
+}
+
+export function recordRpcCall(action = ''): void {
+  if (!enabled) return
+  state.rpcCalls += 1
+  debugLog('rpc', action)
+}
+
+export function recordCacheHit(): void {
+  if (enabled) state.cacheHits += 1
+}
+
+export function debugLogEntries(): DebugLogEntry[] {
+  return log
+}
+
+export function buildDiagnosticText(): string {
+  const lines: string[] = []
+  lines.push('MilkSU debug diagnostics')
+  lines.push(`mode: ${enabled ? 'on' : 'off'}`)
+  lines.push(`view: ${state.view} | bank: ${state.bank}`)
+  lines.push(`fullCatalog: ${state.fullCatalogReady ? 'ready' : 'pending'} (${state.fullCatalogProblems} problems)`)
+  lines.push(`collection problems: ${state.collectionProblems}`)
+  lines.push(`selected platform: ${state.selectedPlatformId ?? 'none'}`)
+  lines.push(`local hits: ${state.localHits} | cache hits: ${state.cacheHits} | rpc calls: ${state.rpcCalls}`)
+  lines.push('')
+  lines.push('-- log --')
+  for (const entry of log) {
+    const duration = entry.durationMs < 0 ? '' : ` ${entry.durationMs.toFixed(0)}ms`
+    lines.push(`${entry.time} [${entry.action}]${duration} ${entry.detail}`)
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## 功能背景

MilkSU 之前缺少一个覆盖应用范围的本地诊断入口。虽然 CTF 收藏视图的偶发残留和切换时序问题已经通过独立 PR 修复，但后续仍需要在不暴露凭据和用户内容的前提下观察应用操作、Desktop RPC 和目录查询状态。

## 功能实现

- 在设置页“常规”中新增应用级“调试模式”开关，默认关闭。
- 调试模式使用本地内存环形日志，最多保留最近 200 条记录。
- 在统一的 `invokeCommand()` 入口记录 Desktop RPC 命令名和调用次数，不记录 RPC 参数。
- 记录主导航切换、CTF 集合切换、目录加载和目录查询耗时。
- 记录本地目录命中、查询缓存命中和 RPC 查询计数。
- 保存不包含凭据的轻量状态快照，包括当前视图、题库、完整目录是否就绪、题目数量和集合可见数量。
- 设置页提供“一键复制诊断”功能，输出本地诊断文本，不进行网络上报。
- 关闭调试模式时清空日志和计数器；调试开关仅保存本地启用状态。
- RPC 调试打点统一收口到 `invokeCommand()`，避免目录查询重复记录日志或造成计数不一致。
- 明确不采集 Provider API Key、Token、凭据、绝对路径、题目正文或 RPC 参数。

## 用户影响

用户可以在设置页显式开启调试模式，再复现偶发问题并复制诊断文本，而不需要打开开发者工具或导出敏感运行数据。

调试模式关闭时不记录诊断内容，也不改变正常 Agent 回合行为。

## 产品边界与实现选择

- Pi 继续负责 Session、Compaction 和 Tool Loop；本 PR 只增加 MilkSU 自有的桌面诊断投影和设置入口。
- 不新增 Desktop RPC 方法、Preload API、Sidecar 资源、数据库 schema 或网络端点。
- 不构建第二套 Agent Harness，不复制 Pi 的会话或工具循环。
- 日志只存在于本地前端运行时，并通过现有设置页面复制到用户剪贴板。

## 改动范围

本 PR 只包含应用级本地调试模式及其 RPC 打点修复，共修改 8 个文件：

- `app/src/App.vue`
- `app/src/components-vue/CTFPage.vue`
- `app/src/components-vue/SettingsPage.vue`
- `app/src/composables/useNSSCTFTraining.ts`
- `app/src/desktop.test.ts`
- `app/src/desktop.ts`
- `app/src/lib/debugMode.ts`
- `app/src/lib/debugMode.test.ts`

不包含 CTF 收藏视图修复、Windows 换行测试修复、fork 文档或其他同步改动。

## 验证结果

已通过：

- 定向测试：3 个测试文件、41 个测试通过。
- 完整前端测试：79 个测试文件、492 个测试通过。
- `npm --prefix app run lint`：通过。
- `npm --prefix app run build`：`vue-tsc -b` 与 Vite 生产构建通过。
- `git diff --check`：通过。

完整测试过程中出现一条 jsdom 关于 `HTMLCanvasElement.getContext()` 未安装 canvas 包的环境提示，但不影响测试结果。
