### PR TITLE
fix(ui): inline goal, plan and workspace status as composer chips

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -888,9 +888,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -908,9 +905,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +922,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -948,9 +939,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,9 +956,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -988,9 +973,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1008,9 +990,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1028,9 +1007,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,9 +1171,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1213,9 +1186,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1233,9 +1203,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1218,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1271,9 +1235,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1250,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1515,9 +1473,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1533,9 +1488,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1553,9 +1505,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,9 +1520,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3327,9 +3273,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3349,9 +3292,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3373,9 +3313,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3395,9 +3332,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/app/src/components-vue/ChatComposer.test.ts
+++ b/app/src/components-vue/ChatComposer.test.ts
@@ -150,10 +150,11 @@ describe('ChatComposer', () => {
     expect(permission?.getAttribute('title')).toBe('替我审批')
 
     expect(composerControlsSource).toContain('background-color: var(--btn-ghost-hover) !important;')
-    expect(composerControlsSource).toContain('min-width: 7.75rem;')
+    expect(composerControlsSource).toMatch(/(?:^|\n)\.composer-permission \{[\s\S]*?\n\s*width: fit-content;/)
+    expect(composerControlsSource).not.toContain('min-width: 7.75rem;')
+    expect(composerControlsSource).not.toContain('min-width: 7.5rem;')
     expect(composerControlsSource).toContain('.composer-permission__label')
     expect(composerControlsSource).toContain('overflow: visible')
-    expect(composerControlsSource).toContain('width: auto;')
     expect(composerControlsSource).toContain('.composer-model {')
     expect(composerControlsSource).toContain('width: fit-content;')
     expect(composerControlsSource).toContain('flex: 0 1 auto;')

--- a/app/src/components-vue/ChatComposer.test.ts
+++ b/app/src/components-vue/ChatComposer.test.ts
@@ -4,6 +4,7 @@ import { createApp, nextTick, type App } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import ChatComposer from './ChatComposer.vue'
 import composerControlsSource from './CodingComposerControls.vue?raw'
+import composerSource from './ChatComposer.vue?raw'
 import type { CodingGoalState } from '@/types'
 
 const mountedApps: App[] = []
@@ -714,6 +715,21 @@ describe('ChatComposer', () => {
     document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
     await nextTick()
     expect(panel?.style.display).toBe('none')
+  })
+
+  it('collapses the goal chip to an icon and lets the progress pill shrink in narrow containers', () => {
+    const source = composerSource.replace(/\r\n/g, '\n')
+    const narrowBlockStart = source.indexOf('@container chat-main (max-width: 36rem)')
+    expect(narrowBlockStart).toBeGreaterThan(-1)
+    const narrowBlock = source.slice(narrowBlockStart)
+
+    expect(narrowBlock).toContain('.chat-composer__chip--goal {\n    width: 2rem;')
+    expect(narrowBlock).toContain(
+      '.chat-composer__chip--goal .chat-composer__chip__label,\n'
+      + '  .chat-composer__chip--goal .chat-composer__chip__chevron {\n'
+      + '    display: none;\n  }',
+    )
+    expect(narrowBlock).toContain('.chat-composer__progress-pill {\n    min-width: 0;')
   })
 
   it('projects real goal and Git status above the composer with goal controls', async () => {

--- a/app/src/components-vue/ChatComposer.test.ts
+++ b/app/src/components-vue/ChatComposer.test.ts
@@ -668,6 +668,54 @@ describe('ChatComposer', () => {
     expect(disabledGoal?.textContent).toContain('当前已有持续目标')
   })
 
+  it('does not render the goal chip when only Git progress exists without a goal', async () => {
+    const result = mountComposer({
+      gitSummary: {
+        changedFiles: 3,
+        additions: 10,
+        deletions: 2,
+        changes: [],
+      },
+    })
+    await nextTick()
+
+    expect(result.host.querySelector('[aria-label="持续目标"]')).toBeNull()
+    expect(result.host.querySelector('[aria-label="任务进度摘要"]')).not.toBeNull()
+    expect(result.host.querySelector('[aria-label="任务进度摘要"]')?.textContent)
+      .toContain('代码')
+  })
+
+  it('closes the goal popover with Escape from keyboard focus and with outside pointer clicks', async () => {
+    const result = mountComposer({ goal: activeGoal })
+    await nextTick()
+
+    const chip = result.host.querySelector<HTMLButtonElement>('.chat-composer__chip--goal')
+    const panel = result.host.querySelector<HTMLElement>('.chat-composer__goal-panel')
+    expect(chip).not.toBeNull()
+    expect(panel?.style.display).toBe('none')
+
+    chip?.focus()
+    chip?.click()
+    await nextTick()
+    expect(panel?.style.display).not.toBe('none')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    }))
+    await nextTick()
+    expect(panel?.style.display).toBe('none')
+
+    chip?.click()
+    await nextTick()
+    expect(panel?.style.display).not.toBe('none')
+
+    document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await nextTick()
+    expect(panel?.style.display).toBe('none')
+  })
+
   it('projects real goal and Git status above the composer with goal controls', async () => {
     const active = mountComposer({
       goal: activeGoal,

--- a/app/src/components-vue/ChatComposer.vue
+++ b/app/src/components-vue/ChatComposer.vue
@@ -378,7 +378,7 @@ const showProgressSummary = computed(() => Boolean(
   (props.goal?.iteration ?? 0) > 0 || showGitSummary.value,
 ))
 const showGoalDock = computed(() => Boolean(
-  !props.ctfSession && (props.goal || props.goalMode || showProgressSummary.value),
+  !props.ctfSession && (props.goal || props.goalMode),
 ))
 const goalPanelOpen = ref(false)
 const goalSlot = ref<HTMLElement | null>(null)
@@ -388,19 +388,23 @@ watch(showGoalDock, visible => {
 watch(() => props.goal, goal => {
   if (!goal) goalPanelOpen.value = false
 })
-function closeGoalPanelOnOutsideEvent(event: Event) {
+function closeGoalPanelOnEscape(event: KeyboardEvent) {
+  if (!goalPanelOpen.value || event.key !== 'Escape') return
+  event.preventDefault()
+  goalPanelOpen.value = false
+}
+function closeGoalPanelOnOutsidePointer(event: PointerEvent) {
   if (!goalPanelOpen.value) return
-  if (event instanceof KeyboardEvent && event.key !== 'Escape') return
   const slot = goalSlot.value
   if (slot && !slot.contains(event.target as Node)) goalPanelOpen.value = false
 }
 onMounted(() => {
-  document.addEventListener('pointerdown', closeGoalPanelOnOutsideEvent)
-  document.addEventListener('keydown', closeGoalPanelOnOutsideEvent)
+  document.addEventListener('pointerdown', closeGoalPanelOnOutsidePointer)
+  document.addEventListener('keydown', closeGoalPanelOnEscape)
 })
 onBeforeUnmount(() => {
-  document.removeEventListener('pointerdown', closeGoalPanelOnOutsideEvent)
-  document.removeEventListener('keydown', closeGoalPanelOnOutsideEvent)
+  document.removeEventListener('pointerdown', closeGoalPanelOnOutsidePointer)
+  document.removeEventListener('keydown', closeGoalPanelOnEscape)
 })
 function toggleGoalChip() {
   if (props.goal) {

--- a/app/src/components-vue/ChatComposer.vue
+++ b/app/src/components-vue/ChatComposer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, markRaw, nextTick, ref, watch, type Component } from 'vue'
+import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref, watch, type Component } from 'vue'
 import {
   Button,
   DropdownMenu,
@@ -18,6 +18,7 @@ import {
   Bot,
   Cable,
   Check,
+  ChevronDown,
   Clock3,
   Compass,
   FileDiff,
@@ -119,6 +120,8 @@ const props = defineProps<{
   runElapsedLabel?: string
   workspaceReady?: boolean
   workspaceLocked?: boolean
+  workspaceName?: string
+  workspacePath?: string
   browserUseReady?: boolean
   computerUseReady?: boolean
   availableSkills?: string[]
@@ -377,6 +380,45 @@ const showProgressSummary = computed(() => Boolean(
 const showGoalDock = computed(() => Boolean(
   !props.ctfSession && (props.goal || props.goalMode || showProgressSummary.value),
 ))
+const goalPanelOpen = ref(false)
+const goalSlot = ref<HTMLElement | null>(null)
+watch(showGoalDock, visible => {
+  if (!visible) goalPanelOpen.value = false
+})
+watch(() => props.goal, goal => {
+  if (!goal) goalPanelOpen.value = false
+})
+function closeGoalPanelOnOutsideEvent(event: Event) {
+  if (!goalPanelOpen.value) return
+  if (event instanceof KeyboardEvent && event.key !== 'Escape') return
+  const slot = goalSlot.value
+  if (slot && !slot.contains(event.target as Node)) goalPanelOpen.value = false
+}
+onMounted(() => {
+  document.addEventListener('pointerdown', closeGoalPanelOnOutsideEvent)
+  document.addEventListener('keydown', closeGoalPanelOnOutsideEvent)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', closeGoalPanelOnOutsideEvent)
+  document.removeEventListener('keydown', closeGoalPanelOnOutsideEvent)
+})
+function toggleGoalChip() {
+  if (props.goal) {
+    goalPanelOpen.value = !goalPanelOpen.value
+  } else {
+    emit('consumeGoal')
+  }
+}
+const showWorkspaceChip = computed(() => Boolean(
+  !props.ctfSession && (props.workspaceName?.trim() || !props.workspaceLocked),
+))
+const workspaceChipLabel = computed(() => props.workspaceName?.trim() || '选择目录')
+const workspaceChipTitle = computed(() => {
+  if (props.workspaceLocked) {
+    return `${props.workspacePath || workspaceChipLabel.value} · 当前会话目录已固定，点击为新任务选择其他目录`
+  }
+  return props.workspacePath || '选择当前任务的会话目录'
+})
 
 const ctfActionOptions = computed(() => {
   const mode = props.ctfMode ?? 'copilot'
@@ -1122,136 +1164,6 @@ defineExpose({
         </button>
       </div>
 
-      <div
-        v-if="showGoalDock"
-        class="chat-composer__dock"
-        aria-label="任务与目标状态"
-      >
-        <div
-          v-if="showProgressSummary"
-          class="chat-composer__progress-pill"
-          aria-label="任务进度摘要"
-        >
-          <LoaderCircle
-            v-if="goal?.status === 'active'"
-            class="size-3.5 shrink-0 text-primary"
-            :class="{ 'animate-spin': running }"
-          />
-          <span v-if="goal?.iteration">第 {{ goal.iteration }} 轮</span>
-          <span v-if="goal?.iteration && showGitSummary" aria-hidden="true">·</span>
-          <HoverCard v-if="showGitSummary" :open-delay="120" :close-delay="80">
-            <HoverCardTrigger as-child>
-              <button
-                type="button"
-                class="chat-composer__git-trigger"
-                aria-label="查看代码变更"
-                @click="$emit('openChanges')"
-              >
-                <span>代码</span>
-                <span class="text-primary">+{{ gitSummary?.additions }}</span>
-                <span class="text-destructive">-{{ gitSummary?.deletions }}</span>
-              </button>
-            </HoverCardTrigger>
-            <HoverCardContent side="top" align="start" class="w-96 p-0">
-              <div class="border-b border-border px-3 py-2.5">
-                <p class="text-label font-medium">{{ gitSummary?.changedFiles }} 个文件已更改</p>
-                <p class="mt-0.5 text-caption text-muted-foreground">点击“代码”打开右侧变更面板</p>
-              </div>
-              <div class="max-h-64 overflow-y-auto px-2 py-2">
-                <button
-                  v-for="change in gitSummary?.changes ?? []"
-                  :key="`${change.indexStatus}${change.worktreeStatus}:${change.path}`"
-                  type="button"
-                  class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-caption hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  :aria-label="`在变更中打开 ${change.path}`"
-                  @click="$emit('openChanges', change.path)"
-                >
-                  <span class="w-14 shrink-0 text-muted-foreground">{{ gitChangeStatus(change) }}</span>
-                  <span class="min-w-0 flex-1 truncate font-mono" :title="change.path">{{ change.path }}</span>
-                  <span class="shrink-0 font-mono text-primary">+{{ change.additions ?? 0 }}</span>
-                  <span class="shrink-0 font-mono text-destructive">-{{ change.deletions ?? 0 }}</span>
-                </button>
-                <p v-if="!(gitSummary?.changes?.length)" class="px-2 py-2 text-caption text-muted-foreground">
-                  文件列表正在刷新；点击后可查看完整变更。
-                </p>
-                <p v-if="gitSummary?.changesTruncated" class="px-2 py-1 text-caption text-muted-foreground">
-                  仅显示前 {{ gitSummary?.changes?.length ?? 0 }} 项。
-                </p>
-              </div>
-            </HoverCardContent>
-          </HoverCard>
-        </div>
-
-        <section
-          v-if="goal || goalMode"
-          class="chat-composer__goal-panel"
-          aria-label="持续目标"
-        >
-          <Target class="size-4 shrink-0 text-primary" />
-          <span class="shrink-0 text-caption font-medium text-primary">
-            {{ goal ? goalStatusLabel : '正在设置' }}
-          </span>
-          <span class="min-w-0 flex-1 truncate text-body" :title="goal?.text">
-            {{ goal?.text || '下一条消息会成为持续目标。' }}
-          </span>
-          <span
-            v-if="goalUsageLabel"
-            class="hidden shrink-0 text-caption text-muted-foreground sm:inline"
-          >
-            {{ goalUsageLabel }}
-          </span>
-          <div class="flex shrink-0 items-center gap-1">
-            <Button
-              v-if="goal?.status === 'active'"
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              :disabled="aborting"
-              :aria-label="aborting ? '正在暂停目标' : '暂停目标'"
-              :title="aborting ? '正在等待当前回合停止' : '暂停持续目标'"
-              @click="$emit('controlGoal', 'pause')"
-            >
-              <LoaderCircle v-if="aborting" class="size-3.5 animate-spin" />
-              <Pause v-else class="size-3.5" />
-            </Button>
-            <Button
-              v-if="goal && resumableGoal"
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              :disabled="running"
-              aria-label="继续目标"
-              title="继续持续目标"
-              @click="$emit('controlGoal', 'resume')"
-            >
-              <Play class="size-3.5" />
-            </Button>
-            <Button
-              v-if="goal && !running"
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label="清除当前目标"
-              title="清除当前目标"
-              @click="$emit('controlGoal', 'clear')"
-            >
-              <Trash2 class="size-3.5" />
-            </Button>
-            <Button
-              v-else-if="goalMode && !goal"
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label="取消目标模式"
-              title="取消目标模式"
-              @click="$emit('consumeGoal')"
-            >
-              <X class="size-3.5" />
-            </Button>
-          </div>
-        </section>
-      </div>
-
       <section
         v-if="queuedGuidance?.length"
         class="chat-composer__queued-guidance"
@@ -1521,6 +1433,183 @@ defineExpose({
                 </DropdownMenuContent>
               </DropdownMenu>
             </template>
+            <template #status>
+              <div
+                v-if="showGoalDock"
+                ref="goalSlot"
+                class="chat-composer__goal-slot"
+                aria-label="持续目标"
+              >
+                <button
+                  type="button"
+                  class="chat-composer__chip chat-composer__chip--goal"
+                  :aria-haspopup="goal ? 'true' : undefined"
+                  :aria-expanded="goal ? goalPanelOpen : undefined"
+                  :title="goal
+                    ? `持续目标：${goal.text}（点击展开）`
+                    : '目标模式已开启；下一条消息会成为持续目标，点击退出'"
+                  @click="toggleGoalChip"
+                >
+                  <Target class="size-3.5 shrink-0" />
+                  <span class="chat-composer__chip__label">
+                    {{ goal ? goalStatusLabel : '目标' }}
+                  </span>
+                  <ChevronDown class="chat-composer__chip__chevron size-3 shrink-0 opacity-60" />
+                </button>
+                <div
+                  v-show="goalPanelOpen"
+                  class="chat-composer__goal-panel"
+                  aria-label="持续目标详情"
+                >
+                  <div class="flex items-center gap-2">
+                    <Target class="size-4 shrink-0 text-primary" />
+                    <span class="shrink-0 text-caption font-medium text-primary">
+                      {{ goal ? goalStatusLabel : '正在设置' }}
+                    </span>
+                    <span
+                      v-if="goalUsageLabel"
+                      class="ml-auto shrink-0 text-caption text-muted-foreground"
+                    >
+                      {{ goalUsageLabel }}
+                    </span>
+                  </div>
+                  <p class="mt-2 truncate text-body" :title="goal?.text">
+                    {{ goal?.text || '下一条消息会成为持续目标。' }}
+                  </p>
+                  <div class="mt-3 flex items-center gap-1">
+                    <Button
+                      v-if="goal?.status === 'active'"
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      :disabled="aborting"
+                      :aria-label="aborting ? '正在暂停目标' : '暂停目标'"
+                      :title="aborting ? '正在等待当前回合停止' : '暂停持续目标'"
+                      @click="$emit('controlGoal', 'pause')"
+                    >
+                      <LoaderCircle v-if="aborting" class="size-3.5 animate-spin" />
+                      <Pause v-else class="size-3.5" />
+                    </Button>
+                    <Button
+                      v-if="goal && resumableGoal"
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      :disabled="running"
+                      aria-label="继续目标"
+                      title="继续持续目标"
+                      @click="$emit('controlGoal', 'resume')"
+                    >
+                      <Play class="size-3.5" />
+                    </Button>
+                    <Button
+                      v-if="goal && !running"
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="清除当前目标"
+                      title="清除当前目标"
+                      @click="$emit('controlGoal', 'clear')"
+                    >
+                      <Trash2 class="size-3.5" />
+                    </Button>
+                    <Button
+                      v-else-if="goalMode && !goal"
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="取消目标模式"
+                      title="取消目标模式"
+                      @click="$emit('consumeGoal')"
+                    >
+                      <X class="size-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+              <button
+                v-if="!ctfSession && executionMode === 'plan'"
+                type="button"
+                class="chat-composer__chip chat-composer__chip--plan"
+                aria-label="计划模式已开启"
+                title="只分析和规划，不修改文件；点击退出计划模式"
+                @click="$emit('changeExecutionMode', 'go')"
+              >
+                <Lightbulb class="size-3.5 shrink-0" />
+                <span class="chat-composer__chip__label">计划</span>
+              </button>
+              <div
+                v-if="!ctfSession && showProgressSummary"
+                class="chat-composer__progress-pill"
+                aria-label="任务进度摘要"
+              >
+                <LoaderCircle
+                  v-if="goal?.status === 'active'"
+                  class="size-3.5 shrink-0 text-primary"
+                  :class="{ 'animate-spin': running }"
+                />
+                <span v-if="goal?.iteration">第 {{ goal.iteration }} 轮</span>
+                <span v-if="goal?.iteration && showGitSummary" aria-hidden="true">·</span>
+                <HoverCard v-if="showGitSummary" :open-delay="120" :close-delay="80">
+                  <HoverCardTrigger as-child>
+                    <button
+                      type="button"
+                      class="chat-composer__git-trigger"
+                      aria-label="查看代码变更"
+                      @click="$emit('openChanges')"
+                    >
+                      <span>代码</span>
+                      <span class="text-primary">+{{ gitSummary?.additions }}</span>
+                      <span class="text-destructive">-{{ gitSummary?.deletions }}</span>
+                    </button>
+                  </HoverCardTrigger>
+                  <HoverCardContent side="top" align="start" class="w-96 p-0">
+                    <div class="border-b border-border px-3 py-2.5">
+                      <p class="text-label font-medium">{{ gitSummary?.changedFiles }} 个文件已更改</p>
+                      <p class="mt-0.5 text-caption text-muted-foreground">点击“代码”打开右侧变更面板</p>
+                    </div>
+                    <div class="max-h-64 overflow-y-auto px-2 py-2">
+                      <button
+                        v-for="change in gitSummary?.changes ?? []"
+                        :key="`${change.indexStatus}${change.worktreeStatus}:${change.path}`"
+                        type="button"
+                        class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-caption hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        :aria-label="`在变更中打开 ${change.path}`"
+                        @click="$emit('openChanges', change.path)"
+                      >
+                        <span class="w-14 shrink-0 text-muted-foreground">{{ gitChangeStatus(change) }}</span>
+                        <span class="min-w-0 flex-1 truncate font-mono" :title="change.path">{{ change.path }}</span>
+                        <span class="shrink-0 font-mono text-primary">+{{ change.additions ?? 0 }}</span>
+                        <span class="shrink-0 font-mono text-destructive">-{{ change.deletions ?? 0 }}</span>
+                      </button>
+                      <p v-if="!(gitSummary?.changes?.length)" class="px-2 py-2 text-caption text-muted-foreground">
+                        文件列表正在刷新；点击后可查看完整变更。
+                      </p>
+                      <p v-if="gitSummary?.changesTruncated" class="px-2 py-1 text-caption text-muted-foreground">
+                        仅显示前 {{ gitSummary?.changes?.length ?? 0 }} 项。
+                      </p>
+                    </div>
+                  </HoverCardContent>
+                </HoverCard>
+              </div>
+            </template>
+            <template v-if="showWorkspaceChip" #context>
+              <button
+                type="button"
+                class="chat-composer__chip chat-composer__chip--workspace"
+                :disabled="running"
+                :aria-label="`会话目录：${workspaceChipLabel}`"
+                :title="workspaceChipTitle"
+                @click="$emit('chooseWorkspace')"
+              >
+                <FolderOpen class="size-3.5 shrink-0" />
+                <span class="chat-composer__chip__label">{{ workspaceChipLabel }}</span>
+                <ChevronDown
+                  v-if="!workspaceLocked"
+                  class="chat-composer__chip__chevron size-3 shrink-0 opacity-60"
+                />
+              </button>
+            </template>
           </CodingComposerControls>
           <Button
               v-if="running && (!draft.trim() || aborting)"
@@ -1673,45 +1762,110 @@ defineExpose({
   box-shadow: 0 0 0 2px var(--ring);
 }
 
-.chat-composer__dock {
-  display: flex;
+.chat-composer__goal-slot {
+  position: relative;
+  display: inline-flex;
   min-width: 0;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0 0.4rem 0.65rem;
 }
 
-.chat-composer__progress-pill,
+.chat-composer__chip {
+  display: inline-flex;
+  height: 2rem;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 9999px;
+  padding-inline: 0.6rem;
+  font-size: var(--text-body);
+  line-height: var(--text-body--line-height);
+  color: var(--foreground);
+  transition: background-color 110ms ease, color 110ms ease;
+}
+
+.chat-composer__chip:hover:not(:disabled),
+.chat-composer__chip[aria-expanded='true'] {
+  background: var(--btn-ghost-hover);
+}
+
+.chat-composer__chip:disabled {
+  opacity: 0.55;
+}
+
+.chat-composer__chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-composer__chip--goal {
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  color: color-mix(in srgb, var(--primary) 72%, var(--foreground));
+}
+
+.chat-composer__chip--plan {
+  color: var(--muted-foreground);
+}
+
+.chat-composer__chip--plan:hover:not(:disabled) {
+  color: var(--foreground);
+}
+
+.chat-composer__chip--workspace {
+  max-width: 11rem;
+  color: var(--muted-foreground);
+}
+
+.chat-composer__chip--workspace:hover:not(:disabled) {
+  color: var(--foreground);
+}
+
 .chat-composer__goal-panel {
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
-  background: color-mix(in srgb, var(--card) 94%, transparent);
-  box-shadow: 0 6px 18px rgb(0 0 0 / 8%);
-  backdrop-filter: blur(14px);
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 30;
+  width: min(24rem, calc(100vw - 2rem));
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: var(--card);
+  padding: 0.75rem 0.85rem;
+  box-shadow:
+    0 18px 42px rgb(0 0 0 / 18%),
+    0 3px 10px rgb(0 0 0 / 10%);
 }
 
 .chat-composer__progress-pill {
   display: inline-flex;
-  min-height: 2.25rem;
+  min-height: 2rem;
   align-items: center;
   gap: 0.4rem;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
   border-radius: 999px;
-  padding: 0.4rem 0.85rem;
+  background: color-mix(in srgb, var(--card) 94%, transparent);
+  padding: 0.25rem 0.75rem;
   font-size: var(--text-caption);
   color: var(--muted-foreground);
 }
 
-.chat-composer__goal-panel {
-  display: inline-flex;
-  min-width: 0;
-  min-height: 2.25rem;
-  max-width: min(36rem, 100%);
-  flex: 0 1 auto;
-  align-items: center;
-  gap: 0.45rem;
-  border-radius: 9999px;
-  padding: 0.35rem 0.4rem 0.35rem 0.75rem;
+@container chat-main (max-width: 40rem) {
+  .chat-composer__chip--workspace {
+    max-width: 7rem;
+  }
+}
+
+@container chat-main (max-width: 36rem) {
+  .chat-composer__chip--workspace {
+    max-width: 2rem;
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  .chat-composer__chip--workspace .chat-composer__chip__label,
+  .chat-composer__chip--workspace .chat-composer__chip__chevron {
+    display: none;
+  }
 }
 
 .composer-add-option {

--- a/app/src/components-vue/ChatComposer.vue
+++ b/app/src/components-vue/ChatComposer.vue
@@ -1870,6 +1870,23 @@ defineExpose({
   .chat-composer__chip--workspace .chat-composer__chip__chevron {
     display: none;
   }
+
+  .chat-composer__chip--goal {
+    width: 2rem;
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  .chat-composer__chip--goal .chat-composer__chip__label,
+  .chat-composer__chip--goal .chat-composer__chip__chevron {
+    display: none;
+  }
+
+  .chat-composer__progress-pill {
+    min-width: 0;
+    overflow: hidden;
+    padding-inline: 0.5rem;
+  }
 }
 
 .composer-add-option {

--- a/app/src/components-vue/ChatPage.vue
+++ b/app/src/components-vue/ChatPage.vue
@@ -558,8 +558,8 @@ const automaticScratchWorkspace = computed(() => (
 ))
 const workspaceName = computed(() => {
   if (automaticScratchWorkspace.value) return '无项目任务'
-  const value = props.workspacePath.replace(/\/+$/, '')
-  return value.split('/').at(-1) || '无项目任务'
+  const value = props.workspacePath.replace(/[/\\]+$/, '')
+  return value.split(/[/\\]/).at(-1) || '无项目任务'
 })
 const codingBrowserEvidencePath = computed(() => {
   const sessionID = codingBrowserStatus.value?.sessionId?.trim()
@@ -1800,7 +1800,7 @@ watch(
             选择项目目录
           </Button>
           <Badge v-else variant="outline" class="max-w-md truncate">
-            {{ domainTaskPresentation ? '任务工作区已就绪' : workspacePath }}
+            {{ domainTaskPresentation ? '任务工作区已就绪' : workspaceName }}
           </Badge>
           <Button v-if="!hasCredential" variant="outline" @click="$emit('openSettings')">
             <KeyRound class="size-4" />
@@ -1849,6 +1849,8 @@ watch(
       :run-elapsed-label="runTimingPresentation?.label"
       :workspace-ready="Boolean(workspacePath)"
       :workspace-locked="workspaceLocked"
+      :workspace-name="workspaceName"
+      :workspace-path="workspacePath"
       :browser-use-ready="browserUseReadyForCurrentTask"
       :computer-use-ready="externalAppUseReadyForCurrentTask"
       :available-skills="activeSkills"

--- a/app/src/components-vue/CodingComposerControls.vue
+++ b/app/src/components-vue/CodingComposerControls.vue
@@ -152,63 +152,67 @@ function triggerModelText() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      <slot name="status" />
     </div>
 
-    <Select
-      :model-value="modelKey"
-      :disabled="running"
-      @update:model-value="value => $emit('changeModel', String(value ?? ''))"
-    >
-      <SelectTrigger
-        size="sm"
-        class="composer-control composer-model min-w-0 rounded-full border-0 bg-transparent shadow-none"
-        aria-label="选择本任务模型"
-        :title="modelKey === 'auto'
-          ? '使用 MilkSU 默认模型；你可以仅为当前对话覆盖'
-          : '当前对话固定使用所选模型'"
+    <div class="flex min-w-0 items-center gap-1.5">
+      <slot name="context" />
+      <Select
+        :model-value="modelKey"
+        :disabled="running"
+        @update:model-value="value => $emit('changeModel', String(value ?? ''))"
       >
-        <SelectValue>
-          <span class="inline-flex min-w-0 items-center gap-1.5">
-            <ModelVendorIcon :model="triggerModelText()" class="opacity-90" />
-            <span class="min-w-0 truncate">{{ compactModelLabel }}</span>
-          </span>
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent size="sm" align="start" :align-offset="0" class="min-w-96">
-        <SelectGroup>
-          <SelectLabel>Default</SelectLabel>
-          <SelectItem value="auto">
-            <span class="inline-flex min-w-0 items-center gap-2">
-              <ModelVendorIcon :model="automaticModelLabel" />
-              <span class="min-w-0 truncate">{{ automaticModelLabel }}</span>
-            </span>
-          </SelectItem>
-        </SelectGroup>
-        <SelectSeparator v-if="pickerGroups.length" />
-        <template
-          v-for="(group, groupIndex) in pickerGroups"
-          :key="group.key"
+        <SelectTrigger
+          size="sm"
+          class="composer-control composer-model min-w-0 rounded-full border-0 bg-transparent shadow-none"
+          aria-label="选择本任务模型"
+          :title="modelKey === 'auto'
+            ? '使用 MilkSU 默认模型；你可以仅为当前对话覆盖'
+            : '当前对话固定使用所选模型'"
         >
-          <SelectSeparator v-if="groupIndex > 0" />
+          <SelectValue>
+            <span class="inline-flex min-w-0 items-center gap-1.5">
+              <ModelVendorIcon :model="triggerModelText()" class="opacity-90" />
+              <span class="min-w-0 truncate">{{ compactModelLabel }}</span>
+            </span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent size="sm" align="start" :align-offset="0" class="min-w-96">
           <SelectGroup>
-            <SelectLabel>{{ group.label }}</SelectLabel>
-            <SelectItem
-              v-for="model in group.models"
-              :key="`${group.key}:${model}`"
-              :value="encodeComposerModelKey(group.providerId, model, group.source)"
-            >
+            <SelectLabel>Default</SelectLabel>
+            <SelectItem value="auto">
               <span class="inline-flex min-w-0 items-center gap-2">
-                <ModelVendorIcon
-                  :model="model"
-                  :label="pickerModelLabel(group, model)"
-                />
-                <span class="min-w-0 truncate">{{ pickerModelLabel(group, model) }}</span>
+                <ModelVendorIcon :model="automaticModelLabel" />
+                <span class="min-w-0 truncate">{{ automaticModelLabel }}</span>
               </span>
             </SelectItem>
           </SelectGroup>
-        </template>
-      </SelectContent>
-    </Select>
+          <SelectSeparator v-if="pickerGroups.length" />
+          <template
+            v-for="(group, groupIndex) in pickerGroups"
+            :key="group.key"
+          >
+            <SelectSeparator v-if="groupIndex > 0" />
+            <SelectGroup>
+              <SelectLabel>{{ group.label }}</SelectLabel>
+              <SelectItem
+                v-for="model in group.models"
+                :key="`${group.key}:${model}`"
+                :value="encodeComposerModelKey(group.providerId, model, group.source)"
+              >
+                <span class="inline-flex min-w-0 items-center gap-2">
+                  <ModelVendorIcon
+                    :model="model"
+                    :label="pickerModelLabel(group, model)"
+                  />
+                  <span class="min-w-0 truncate">{{ pickerModelLabel(group, model) }}</span>
+                </span>
+              </SelectItem>
+            </SelectGroup>
+          </template>
+        </SelectContent>
+      </Select>
+    </div>
   </div>
 </template>
 

--- a/app/src/components-vue/CodingComposerControls.vue
+++ b/app/src/components-vue/CodingComposerControls.vue
@@ -266,8 +266,8 @@ function triggerModelText() {
 }
 
 .composer-permission {
-  width: auto;
-  min-width: 7.75rem;
+  width: fit-content;
+  min-width: 0;
   max-width: 11rem;
   flex: 0 0 auto;
   padding-inline: 0.55rem 0.45rem;
@@ -342,10 +342,6 @@ function triggerModelText() {
   .composer-controls {
     flex-wrap: nowrap;
     gap: 0.25rem;
-  }
-
-  .composer-permission {
-    min-width: 7.5rem;
   }
 
   .composer-model {

--- a/app/src/lib/chatTopbar.test.ts
+++ b/app/src/lib/chatTopbar.test.ts
@@ -10,7 +10,7 @@ describe('chatTopbarPresentation', () => {
       codingPolicyLabel: 'Go · 项目自动',
     })).toEqual({
       title: '修复导航',
-      subtitle: '/Users/milksu/code/milksu',
+      subtitle: 'milksu',
     })
   })
 
@@ -69,7 +69,7 @@ describe('chatTopbarPresentation', () => {
       codingPolicyLabel: 'Go · 项目自动',
     })).toEqual({
       title: 'CVE',
-      subtitle: 'CVE-2023-46604 研究接力 · /Users/milksu/code/milksu',
+      subtitle: 'CVE-2023-46604 研究接力 · milksu',
     })
   })
 

--- a/app/src/lib/chatTopbar.ts
+++ b/app/src/lib/chatTopbar.ts
@@ -15,6 +15,11 @@ function ctfModeLabel(mode: ChatTopbarInput['ctfMode']) {
   return '搭档'
 }
 
+function workspaceBaseName(path?: string) {
+  const value = (path || '').replace(/[/\\]+$/, '')
+  return value.split(/[/\\]/).at(-1) || ''
+}
+
 export function chatTopbarPresentation(input: ChatTopbarInput) {
   const workspacePath = isGeneratedScratchWorkspace(input.workspacePath)
     ? ''
@@ -26,15 +31,17 @@ export function chatTopbarPresentation(input: ChatTopbarInput) {
     }
   }
 
+  const workspaceLabel = workspacePath ? workspaceBaseName(workspacePath) : ''
+
   if (input.vulnerabilitySession) {
     return {
       title: 'CVE',
-      subtitle: `${input.conversationTitle || 'CVE 接力'} · ${workspacePath || `临时工作区 · ${input.codingPolicyLabel}`}`,
+      subtitle: `${input.conversationTitle || 'CVE 接力'} · ${workspaceLabel || `临时工作区 · ${input.codingPolicyLabel}`}`,
     }
   }
 
   return {
     title: input.conversationTitle || '新编码任务',
-    subtitle: workspacePath || `临时工作区 · ${input.codingPolicyLabel}`,
+    subtitle: workspaceLabel || `临时工作区 · ${input.codingPolicyLabel}`,
   }
 }


### PR DESCRIPTION
Replace the expanded goal dock above the composer with compact chips embedded in the composer control bar for higher information density:

- goal mode renders as a chip next to the approval selector; before a goal exists, clicking it exits goal mode like plan mode instead of opening a setting panel; once a goal exists the chip opens a small popover with status, usage and pause/resume/clear controls
- plan mode renders as a chip that exits plan mode on click
- the session directory renders as a chip showing only the folder base name (Windows backslash paths handled), collapsing to an icon in narrow containers; the full path stays in the tooltip
- the empty-state badge and topbar subtitle show the folder name instead of the full workspace path
- the progress pill (iteration and git summary) moves into the bar

## Review follow-ups

Addressed in `39456aa`, `296680e` and `875b9c9`:

- the goal slot is now bound to `goal || goalMode` only, while the progress pill keeps its own `showProgressSummary` condition, so a green goal chip no longer appears when only Git progress exists (fixes the wrong product state and the stale "goal mode enabled" tooltip from the review screenshot)
- Escape and outside pointerdown handling are split: Escape closes the goal popover directly from keyboard focus, and the `contains` check only applies to outside pointer clicks
- in narrow containers (<= 36rem) the goal chip collapses to the same 2 rem icon-only language as the workspace chip and permission selector, and the progress pill gains `min-width: 0` so it compresses instead of squeezing the goal chip (fixes the overlap shown in the narrow-bar preview)
- the approval policy button (request approval / approve for me / full access) is sized to its content with `width: fit-content` instead of a fixed 7.75rem minimum, removing the large empty area on its right side and matching the model chooser language

## Verification

- `npm run test -- ChatComposer.test.ts`: 27/27 passed, including regression tests for the goal chip visibility condition, keyboard Escape closing, the narrow-container collapse contract, and the permission button content-sizing contract
- `npm run lint` (oxlint): 0 warnings, 0 errors
- `vue-tsc` type check: passed
- the 3 failing tests in `globalStyleContract.test.ts` / `WorkspaceTopBar.test.ts` are pre-existing on the branch base and unrelated to the files changed here
