### PR TITLE
fix(settings): 删除/停用自定义中转站后模型不再落到 TokenFlux

### DIFF
--- a/app/src/components-vue/SettingsPage.test.ts
+++ b/app/src/components-vue/SettingsPage.test.ts
@@ -27,16 +27,18 @@ HTMLElement.prototype.scrollIntoView = () => undefined
 
 const mountedApps: App[] = []
 
-installModelCatalog({
-  provider: 'tokenflux',
-  source: 'remote',
-  credential_source: 'account',
+const defaultTokenFluxCatalog = {
+  provider: 'tokenflux' as const,
+  source: 'remote' as const,
+  credential_source: 'account' as const,
   refreshed_at: '2026-08-13T12:30:00Z',
   models: [
     { id: 'grok-4.5', name: 'Grok 4.5', context_window: 500000, max_tokens: 32768, input: ['text', 'image'] },
     { id: 'grok-4.3', name: 'Grok 4.3', context_window: 1000000, max_tokens: 32768, input: ['text'] },
   ],
-})
+}
+
+installModelCatalog(defaultTokenFluxCatalog)
 
 async function settle() {
   await Promise.resolve()
@@ -56,6 +58,7 @@ afterEach(() => {
   Reflect.deleteProperty(window, 'go')
   Reflect.deleteProperty(window, 'milksu')
   installCustomProviderSettings({})
+  installModelCatalog(defaultTokenFluxCatalog)
 })
 
 interface MountSettingsOptions {
@@ -1175,5 +1178,134 @@ describe('SettingsPage database compatibility', () => {
     const persisted = savedSettings as AppSettings
     expect(persisted.providers.tokenflux.enabled).toBe(false)
     expect(persisted.model_routing.auto_fallback).toBe(false)
+  })
+})
+
+describe('SettingsPage custom relay catalog isolation', () => {
+  function typeInto(input: HTMLInputElement | null, value: string) {
+    expect(input).not.toBeNull()
+    input!.value = value
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  function buttonByText(label: string) {
+    return [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent?.trim() === label)
+  }
+
+  async function addNamedCustomRelay(model: string, name: string) {
+    document.querySelector<HTMLButtonElement>('button[aria-label="新增模型服务"]')?.click()
+    await settle()
+    const dialog = document.querySelector<HTMLElement>('.provider-editor-dialog')
+    expect(dialog).not.toBeNull()
+    typeInto(dialog!.querySelector('input[aria-label="API 端点"]'), 'https://relay.example/v1')
+    typeInto(dialog!.querySelector('input[aria-label="中转站名称"]'), name)
+    typeInto(dialog!.querySelector('input[aria-label="模型 ID 或关键词前缀"]'), model)
+    buttonByText('添加')?.click()
+    await settle()
+    typeInto(dialog!.querySelector('input[aria-label="API Key"]'), 'custom-test-secret')
+    buttonByText('保存')?.click()
+    for (let index = 0; index < 8; index += 1) await settle()
+  }
+
+  async function openTokenFluxEditor() {
+    const row = [...document.querySelectorAll<HTMLElement>('.model-service-row')]
+      .find(item => item.textContent?.includes('TokenFlux 中转站'))
+    expect(row).toBeDefined()
+    const edit = [...row!.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent?.trim() === '编辑')
+    edit?.click()
+    await settle()
+    return document.querySelector<HTMLElement>('.provider-editor-dialog')
+  }
+
+  async function mountEmptyCatalogClient() {
+    installModelCatalog(null)
+    let savedSettings: AppSettings | null = null
+    const settings = withAppSettingsDefaults({
+      active_provider: 'tokenflux',
+      active_model: '',
+      providers: {},
+      relay: {
+        enabled: false,
+        url: 'https://tokenflux.dev/v1',
+        key: '',
+        has_key: false,
+      },
+    } as AppSettings)
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'apikeys',
+      settings,
+      appMethods: {
+        GetModelCatalog: async () => ({
+          provider: 'tokenflux',
+          source: 'bundled',
+          credential_source: 'bundled',
+          models: [],
+        }),
+        SaveSettingsCmd: async (value: unknown) => {
+          savedSettings = value as AppSettings
+        },
+        GetSettings: async () => savedSettings ?? settings,
+        TestAgentModel: async () => ({
+          provider: (savedSettings ?? settings).active_provider,
+          model: (savedSettings ?? settings).active_model,
+          ready: true,
+          latencyMs: 12,
+        }),
+      },
+    })
+  }
+
+  it('does not park a deleted custom relay model under TokenFlux', async () => {
+    await mountEmptyCatalogClient()
+    await addNamedCustomRelay('222', '222')
+
+    const customRow = [...document.querySelectorAll<HTMLElement>('.model-service-row')]
+      .find(row => (row.querySelector('p.font-medium')?.textContent ?? '').trim() === '222')
+    expect(customRow).toBeDefined()
+    const remove = [...customRow!.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent?.trim() === '删除')
+    remove?.click()
+    await settle()
+
+    expect(modelServiceRowTitles()).not.toContain('222')
+    const defaultLabel = (document.querySelector('[aria-label="默认模型"]')?.textContent ?? '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    expect(defaultLabel).not.toContain('222')
+    expect(defaultLabel).not.toContain('TokenFlux · 222')
+
+    const dialog = await openTokenFluxEditor()
+    expect(dialog?.textContent ?? '').not.toContain('222')
+    expect(dialog?.textContent ?? '').toContain('测试连接后显示可用模型')
+  })
+
+  it('does not park a disabled custom relay model under TokenFlux', async () => {
+    await mountEmptyCatalogClient()
+    await addNamedCustomRelay('33', '33')
+
+    const customRow = [...document.querySelectorAll<HTMLElement>('.model-service-row')]
+      .find(row => (row.querySelector('p.font-medium')?.textContent ?? '').trim() === '33')
+    expect(customRow).toBeDefined()
+    const toggle = customRow!.querySelector<HTMLElement>('[role="switch"]')
+    expect(toggle).not.toBeNull()
+    toggle?.click()
+    await settle()
+
+    expect(customRow!.textContent ?? '').toContain('已停用')
+    const defaultLabel = (document.querySelector('[aria-label="默认模型"]')?.textContent ?? '')
+      .replace(/\s+/g, ' ')
+      .trim()
+    expect(defaultLabel).not.toContain('33')
+    expect(defaultLabel).not.toContain('TokenFlux · 33')
+
+    const dialog = await openTokenFluxEditor()
+    expect(dialog?.textContent ?? '').not.toContain('33')
+    expect(dialog?.textContent ?? '').toContain('测试连接后显示可用模型')
   })
 })

--- a/app/src/components-vue/SettingsPage.vue
+++ b/app/src/components-vue/SettingsPage.vue
@@ -417,10 +417,29 @@ function addModelService() {
   notice.value = null
 }
 
+function tokenfluxCatalogModels(): string[] {
+  return modelProviders.value.find(item => item.id === 'tokenflux')?.models ?? []
+}
+
+/** After a custom relay is removed or disabled, do not park its model IDs on TokenFlux. */
+function rehomeDefaultAfterCustomServiceChange(serviceId: string, serviceModels: string[]) {
+  if (!working.value) return
+  alignDefaultModelToEnabledServices()
+  const leaked = new Set(serviceModels.map(model => String(model ?? '').trim()).filter(Boolean))
+  const stillOnService = working.value.active_provider === serviceId
+  const parkedOnTokenflux = working.value.active_provider === 'tokenflux'
+    && leaked.has(working.value.active_model)
+  if (!stillOnService && !parkedOnTokenflux) return
+  working.value.active_provider = 'tokenflux'
+  working.value.active_model = tokenfluxCatalogModels()[0] ?? ''
+}
+
 function removeModelService(id: string) {
   if (!working.value) return
   const config = working.value.providers[id] ?? ensureProviderConfig(id)
   if (!config) return
+  const removedModels = [...(config.models ?? [])]
+  const custom = Boolean(config.custom)
   if (config.custom) {
     delete working.value.providers[id]
   } else {
@@ -433,7 +452,12 @@ function removeModelService(id: string) {
       session_only: false,
     }
   }
-  if (working.value.active_provider === id) ensureProvider('tokenflux')
+  if (custom) {
+    rehomeDefaultAfterCustomServiceChange(id, removedModels)
+  } else if (working.value.active_provider === id) {
+    ensureProvider('tokenflux')
+    alignDefaultModelToEnabledServices()
+  }
   editingProviderID.value = null
   customModelInput.value = ''
 }
@@ -516,14 +540,16 @@ const editingProvider = computed(() => {
 })
 const editingProviderModel = computed(() => {
   if (!editingProviderInfo.value || !working.value) return ''
-  if (editingProviderID.value === working.value.active_provider) return working.value.active_model
-  return editingProviderInfo.value.models[0] ?? ''
+  const models = editingProviderInfo.value.models
+  if (
+    editingProviderID.value === working.value.active_provider
+    && models.includes(working.value.active_model)
+  ) {
+    return working.value.active_model
+  }
+  return models[0] ?? ''
 })
-const editingProviderModels = computed(() => {
-  const models = editingProviderInfo.value?.models ?? []
-  if (models.length || editingProviderID.value !== working.value?.active_provider || !working.value.active_model) return models
-  return [working.value.active_model]
-})
+const editingProviderModels = computed(() => editingProviderInfo.value?.models ?? [])
 const providerEditorOpen = computed({
   get: () => Boolean(editingProviderID.value),
   set: value => {
@@ -631,6 +657,12 @@ function setModelServiceEnabled(row: ModelServiceRow, enabled: boolean) {
     if (row.provider.models[0] && !row.provider.models.includes(working.value.active_model)) {
       working.value.active_model = row.provider.models[0]
     }
+    alignDefaultModelToEnabledServices()
+    return
+  }
+  if (row.provider.id !== 'tokenflux') {
+    rehomeDefaultAfterCustomServiceChange(row.provider.id, row.provider.models ?? config.models ?? [])
+    return
   }
   alignDefaultModelToEnabledServices()
 }

--- a/app/src/modelCatalog.test.ts
+++ b/app/src/modelCatalog.test.ts
@@ -71,6 +71,36 @@ describe('runtime model catalog', () => {
       .toBe('Team Relay · vendor/model:preview')
   })
 
+  it('clears the in-memory TokenFlux catalog when given null', () => {
+    installModelCatalog({
+      provider: 'tokenflux',
+      source: 'remote',
+      credential_source: 'account',
+      refreshed_at: '2026-08-18T00:00:00Z',
+      models: [
+        {
+          id: 'grok-4.5', name: 'Grok 4.5',
+          context_window: 500000, max_tokens: 32768, input: ['text', 'image'],
+        },
+      ],
+    })
+    installAppModelSettings({
+      providers: {},
+      relay: {
+        enabled: true,
+        url: 'https://tokenflux.dev/v1',
+        key: '',
+        has_key: true,
+      },
+    })
+    expect(useModelCatalog().providers.value.find(provider => provider.id === 'tokenflux')?.models)
+      .toEqual(['grok-4.5'])
+
+    installModelCatalog(null)
+    expect(useModelCatalog().providers.value.some(provider => provider.id === 'tokenflux'))
+      .toBe(false)
+  })
+
   it('hides unconfigured custom relays from runtime pickers', () => {
     installModelCatalog({
       provider: 'tokenflux',

--- a/app/src/modelCatalog.ts
+++ b/app/src/modelCatalog.ts
@@ -392,6 +392,10 @@ function isScopedSettings(value: ModelCatalogScope): value is {
 }
 
 export function installModelCatalog(snapshot?: ModelCatalogSnapshot | null) {
+  if (snapshot === null) {
+    current.value = null
+    return
+  }
   if (!snapshot || snapshot.provider !== 'tokenflux' || !Array.isArray(snapshot.models)) return
   const seen = new Set<string>()
   const models = snapshot.models.filter(model => {

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -98,6 +98,10 @@
 - Windows Computer Use 沿用 macOS 的有界 Cua 会话：按绝对可执行文件绑定目标、用 Electron 主进程 PID 排除宿主窗口。可见浏览器窗口也是合法 Computer Use 目标；隔离“浏览器”和 Browser Use 仍是另外两条表面，不互相替代。Start/Restore 生命周期与本机 Notepad 窗口枚举已覆盖。本机已用 sidecar 查找路径中的补丁版 `cua-driver 0.14.2` 对可见窗口完成 `observe -> type_text -> observe`，token 回读成功；同一 Driver 对独立 Chrome 窗口完成输入框输入和按钮点击，页面从 `idle` 变为 `visited hello cua`。Chrome 会丢弃后台键盘投递，需前台 `type_text`。Driver 先走安装包/Sidecar 自带副本；缺失时用户启动 Computer Use 可由类型化 `prepare_computer_use_driver` 把 MilkSU 审阅过的 Driver 拷到本机配置目录或按仓库脚本构建，不运行 Cua 官方安装脚本，也不回退到系统级全局控制。官方未打补丁的 Windows 包无法在 bounded 策略下对上可执行文件身份。发行 Windows 包仍由 sidecar 源码构建并打入安装包，不是一次新的三端发行。macOS Computer Use 路径未改。
 - CTF / CVE 的模型操作工作台 UX 后置，不在本轮把 `milksu_workspace` 扩到那两个模块。
 
+### 设置 / 模型服务
+
+- 空 TokenFlux 目录时，删除或停用自定义中转站不会再把它的模型 ID 接到 TokenFlux 默认选择或「可用模型」里（#11）。
+
 ### 发行工具
 
 - 本机默认走 Personal Vault 签名；`release:github` 必须创建/刷新 GitHub Release 页。


### PR DESCRIPTION
Fixes #11

## 问题

从未拉到 TokenFlux 目录的客户端里，添加自定义中转并填写模型 `222` / `33` 后，删除或停用该中转，默认模型和 TokenFlux「可用模型」会把这个 ID 显示成 `TokenFlux · 222`。

根因是删/停之后把 `active_provider` 拨回 TokenFlux，却留下中转的 `active_model`；TokenFlux 编辑框在目录为空时又用 `active_model` 冒充可用列表。

## 修改

- 删除或停用自定义中转后，把默认选择迁回仍可用的服务；若只剩空的 TokenFlux，清空那个不属于目录的模型 ID
- TokenFlux「可用模型」只显示目录里的模型，不再用当前默认模型垫一条
- 设置页补上 issue 的两条复现路径；`installModelCatalog(null)` 可清内存目录

未打包、未做真实桌面验收。`cmd/milksu-backend/app_account_model_test.go` 的本地未提交改动未纳入本 PR。