### PR TITLE
feat(coding): improve project session notifications

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -16,6 +16,7 @@ import {
 import { settingsReturnSection, type CTFWorkspaceSection } from '@/lib/workspaceNavigation'
 import { executeVulnerabilityCodingHandoff } from '@/lib/vulnerabilityCodingHandoff'
 import { debugLog } from '@/lib/debugMode'
+import { groupCodingConversations } from '@/lib/codingConversationGroups'
 import { buildCTFDomainTaskContext } from '@/lib/domainTaskContext'
 import {
   rememberWorkspaceConversation,
@@ -81,6 +82,9 @@ const continueWithoutAccount = ref(readLocalAccountMode())
 const updateStatus = ref<UpdateStatus | null>(null)
 const dismissedUpdateVersion = ref('')
 const themeMode = ref<ThemeMode>(readThemeMode())
+const codingProjects = computed(() => groupCodingConversations(conversations.conversations.value)
+  .filter(group => !group.temporary && group.path)
+  .map(group => ({ name: group.name, path: group.path as string })))
 let unlistenAccount: (() => void) | undefined
 let unlistenModelCatalog: (() => void) | undefined
 let unlistenUpdate: (() => void) | undefined
@@ -311,6 +315,17 @@ async function chooseAgentWorkspaceForNewTask() {
   if (!workspacePath) return
   newConversation()
   conversations.setWorkspace(workspacePath)
+}
+
+function selectCodingProject(workspacePath: string) {
+  conversations.startNew()
+  conversations.setWorkspace(workspacePath)
+  section.value = 'chat'
+}
+
+function newCodingProjectSession(workspacePath: string) {
+  selectCodingProject(workspacePath)
+  codingConversationDrawerOpen.value = true
 }
 
 async function chooseVulnerabilityCodingWorkspace() {
@@ -549,6 +564,7 @@ onBeforeUnmount(() => {
         :active-section="sidebarSection"
         :active-conversation-id="conversations.activeId.value"
         :conversations="conversations.conversations.value"
+        :running-conversation-ids="conversations.runningConversationIds.value"
         :account-status="accountStatus"
         :ctf-section="ctfSection"
         :coding-context-open="codingConversationDrawerOpen"
@@ -569,6 +585,7 @@ onBeforeUnmount(() => {
           codingConversationDrawerOpen = true
         }"
         @delete-conversation="conversations.remove"
+        @new-project-session="newCodingProjectSession"
         @navigate-ctf="ctfSection = $event"
       />
 
@@ -619,6 +636,7 @@ onBeforeUnmount(() => {
         v-if="section === 'chat'"
         :conversation="conversations.active.value"
         :settings="settings"
+        :project-options="codingProjects"
         :workspace-path="conversations.workspacePath.value"
         :running="conversations.activeRunning.value"
         :aborting="conversations.activeAborting.value"
@@ -654,6 +672,7 @@ onBeforeUnmount(() => {
         @respond-approval="conversations.respondApproval"
         @choose-workspace="chooseAgentWorkspace"
         @choose-workspace-for-new-task="chooseAgentWorkspaceForNewTask"
+        @choose-project="selectCodingProject"
         @cancel-queued-guidance="conversations.cancelQueuedGuidance"
         @edit-queued-guidance="conversations.editQueuedGuidance"
         @change-model="changeModel"

--- a/app/src/components-vue/AppSidebar.test.ts
+++ b/app/src/components-vue/AppSidebar.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { createApp, nextTick, type App } from 'vue'
+import { createApp, h, nextTick, ref, type App } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import AppSidebar from './AppSidebar.vue'
 import appSidebarSource from './AppSidebar.vue?raw'
@@ -187,6 +187,78 @@ describe('AppSidebar', () => {
     const temporaryIdx = html.indexOf('coding-temporary-group')
     expect(projectIdx).toBeGreaterThanOrEqual(0)
     expect(temporaryIdx).toBeGreaterThan(projectIdx)
+  })
+
+  it('shows a completion reminder only after a background run finishes and clears it when opened', async () => {
+    const conversations: Conversation[] = [
+      {
+        id: 'conversation-active',
+        title: '当前会话',
+        createdAt: 20,
+        workspacePath: '/Users/milksu/code/milksu',
+        messages: [],
+      },
+      {
+        id: 'conversation-background',
+        title: '后台会话',
+        createdAt: 10,
+        workspacePath: '/Users/milksu/code/milksu',
+        messages: [],
+      },
+    ]
+    const runningIds = ref(['conversation-background'])
+    const selectedId = ref('conversation-active')
+    const host = document.createElement('div')
+    document.body.append(host)
+    const app = createApp({
+      setup: () => () => h(AppSidebar, {
+        activeSection: 'chat',
+        accountStatus: { configured: false, authenticated: false, state: 'unconfigured' },
+        activeConversationId: selectedId.value,
+        conversations,
+        runningConversationIds: runningIds.value,
+        ctfSection: 'catalog',
+        codingContextOpen: true,
+        themeMode: 'dark',
+        onSelectConversation: (id: string) => { selectedId.value = id },
+      }),
+    })
+    app.mount(host)
+    mountedApps.push(app)
+    await nextTick()
+
+    expect(host.querySelector('[aria-label="运行中"]')).not.toBeNull()
+    expect(host.querySelector('[aria-label="有新消息"]')).toBeNull()
+
+    runningIds.value = []
+    await nextTick()
+    expect(host.querySelector('[aria-label="有新消息"]')).not.toBeNull()
+
+    const background = [...host.querySelectorAll<HTMLButtonElement>('.coding-project-child')]
+      .find(button => button.textContent?.includes('后台会话'))
+    background?.click()
+    await nextTick()
+    expect(host.querySelector('[aria-label="有新消息"]')).toBeNull()
+  })
+
+  it('uses a hover-only plus action without project conversation counts', async () => {
+    const conversations: Conversation[] = [{
+      id: 'conversation-1',
+      title: '实现产品闭环',
+      createdAt: Date.now(),
+      workspacePath: '/Users/milksu/code/milksu',
+      messages: [],
+    }]
+    const host = await mountSidebar('chat', conversations, 'dark', vi.fn(), true)
+    const projectSummary = host.querySelector('.coding-project-group summary')
+    const add = projectSummary?.querySelector<HTMLButtonElement>('.coding-project-new-session')
+
+    expect(projectSummary?.textContent?.trim()).toBe('milksu')
+    expect(add?.querySelector('svg.lucide-plus')).not.toBeNull()
+    expect(add?.querySelector('svg.lucide-message-square-plus')).toBeNull()
+    expect(add?.className).toContain('opacity-0')
+    expect(add?.className).toContain('group-hover:opacity-100')
+    expect(contextSidebarSource).not.toContain('coding-project-count')
   })
 
   it('marks the current Coding conversation so day mode can reuse the night selected wash', async () => {

--- a/app/src/components-vue/AppSidebar.vue
+++ b/app/src/components-vue/AppSidebar.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
   accountStatus: AccountStatus
   activeConversationId: string | null
   conversations: Conversation[]
+  runningConversationIds?: string[]
   ctfSection: CTFWorkspaceSection
   /** Coding history panel: fixed beside the rail, not a floating overlay. */
   codingContextOpen?: boolean
@@ -27,6 +28,7 @@ const emit = defineEmits<{
   toggleTheme: []
   selectConversation: [id: string]
   deleteConversation: [id: string]
+  newProjectSession: [workspacePath: string]
   navigateCtf: [value: CTFWorkspaceSection]
   openCodingContext: []
   /** Collapse the open Coding history panel (button lives in the panel header). */
@@ -68,11 +70,13 @@ const showCodingHistory = computed(() => (
         active-section="chat"
         :active-conversation-id="activeConversationId"
         :conversations="conversations"
+        :running-conversation-ids="runningConversationIds"
         :ctf-section="ctfSection"
         @new="$emit('new')"
         @collapse="$emit('collapseCodingContext')"
         @select-conversation="$emit('selectConversation', $event)"
         @delete-conversation="$emit('deleteConversation', $event)"
+        @new-project-session="$emit('newProjectSession', $event)"
         @navigate-ctf="$emit('navigateCtf', $event)"
       />
     </section>

--- a/app/src/components-vue/ChatComposer.vue
+++ b/app/src/components-vue/ChatComposer.vue
@@ -129,6 +129,7 @@ const props = defineProps<{
   workspaceLocked?: boolean
   workspaceName?: string
   workspacePath?: string
+  projectOptions?: Array<{ name: string; path: string }>
   browserUseReady?: boolean
   computerUseReady?: boolean
   availableSkills?: string[]
@@ -155,6 +156,8 @@ const emit = defineEmits<{
   runSlashCommand: [command: string]
   controlGoal: [action: 'pause' | 'resume' | 'clear']
   chooseWorkspace: []
+  chooseWorkspaceForNewTask: []
+  chooseProject: [workspacePath: string]
   cancelQueuedGuidance: [index: number]
   editQueuedGuidance: [index: number]
 }>()
@@ -1695,21 +1698,37 @@ defineExpose({
               </div>
             </template>
             <template v-if="showWorkspaceChip" #context>
-              <button
-                type="button"
-                class="chat-composer__chip chat-composer__chip--workspace"
-                :disabled="running"
-                :aria-label="`会话目录：${workspaceChipLabel}`"
-                :title="workspaceChipTitle"
-                @click="$emit('chooseWorkspace')"
-              >
-                <FolderOpen class="size-3.5 shrink-0" />
-                <span class="chat-composer__chip__label">{{ workspaceChipLabel }}</span>
-                <ChevronDown
-                  v-if="!workspaceLocked"
-                  class="chat-composer__chip__chevron size-3 shrink-0 opacity-60"
-                />
-              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                  <button
+                    type="button"
+                    class="chat-composer__chip chat-composer__chip--workspace"
+                    :disabled="running"
+                    :aria-label="`会话目录：${workspaceChipLabel}`"
+                    :title="workspaceChipTitle"
+                  >
+                    <FolderOpen class="size-3.5 shrink-0" />
+                    <span class="chat-composer__chip__label">{{ workspaceChipLabel }}</span>
+                    <ChevronDown class="chat-composer__chip__chevron size-3 shrink-0 opacity-60" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" :side-offset="8" class="w-64">
+                  <DropdownMenuLabel>选择项目</DropdownMenuLabel>
+                  <DropdownMenuItem
+                    v-for="project in projectOptions"
+                    :key="project.path"
+                    @select="$emit('chooseProject', project.path)"
+                  >
+                    <FolderOpen class="size-4 shrink-0" />
+                    <span class="truncate">{{ project.name }}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator v-if="projectOptions?.length" />
+                  <DropdownMenuItem @select="$emit('chooseWorkspaceForNewTask')">
+                    <Plus class="size-4 shrink-0" />
+                    新建项目
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </template>
           </CodingComposerControls>
           <Button

--- a/app/src/components-vue/ChatPage.vue
+++ b/app/src/components-vue/ChatPage.vue
@@ -186,6 +186,7 @@ const props = defineProps<{
   mcpServers?: string[]
   mcpConfigDigest?: string
   ensureConversation: (title?: string) => string
+  projectOptions?: Array<{ name: string; path: string }>
   /** Unsent handoff draft staged by CTF/CVE open path; never auto-starts Pi. */
   pendingComposerDraft?: { prompt: string; visibleText: string } | null
   conversationDrawerOpen?: boolean
@@ -203,6 +204,7 @@ const emit = defineEmits<{
   abort: []
   chooseWorkspace: []
   chooseWorkspaceForNewTask: []
+  chooseProject: [workspacePath: string]
   cancelQueuedGuidance: [index: number]
   editQueuedGuidance: [index: number]
   changeModel: [mode: 'auto' | 'manual', provider?: string, model?: string]
@@ -2054,6 +2056,7 @@ watch(
       :workspace-locked="workspaceLocked"
       :workspace-name="workspaceName"
       :workspace-path="workspacePath"
+      :project-options="projectOptions"
       :browser-use-ready="browserUseReadyForCurrentTask"
       :computer-use-ready="externalAppUseReadyForCurrentTask"
       :available-skills="activeSkills"
@@ -2067,6 +2070,8 @@ watch(
       @change-model="changeModel"
       @show-permissions="showCodingPermissions"
       @choose-workspace="chooseWorkspaceFromCurrentTask"
+      @choose-workspace-for-new-task="$emit('chooseWorkspaceForNewTask')"
+      @choose-project="$emit('chooseProject', $event)"
       @cancel-queued-guidance="$emit('cancelQueuedGuidance', $event)"
       @edit-queued-guidance="$emit('editQueuedGuidance', $event)"
       @consume-goal="goalMode = false"

--- a/app/src/components-vue/ContextSidebar.vue
+++ b/app/src/components-vue/ContextSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
+import AkLoadingMark from '@/components-vue/AkLoadingMark.vue'
 import {
   Button,
   Input,
@@ -10,6 +11,7 @@ import {
   Library,
   MessageSquarePlus,
   PanelLeftClose,
+  Plus,
   Radar,
   Search,
   Trash2,
@@ -30,6 +32,7 @@ const props = defineProps<{
   activeSection: WorkspaceSection
   activeConversationId: string | null
   conversations: Conversation[]
+  runningConversationIds?: string[]
   ctfSection: CTFWorkspaceSection
 }>()
 
@@ -39,23 +42,56 @@ const emit = defineEmits<{
   collapse: []
   selectConversation: [id: string]
   deleteConversation: [id: string]
+  newProjectSession: [workspacePath: string]
   navigateCtf: [value: CTFWorkspaceSection]
 }>()
+
+const unreadConversationIds = ref(new Set<string>())
+let observedRunningIds: Set<string> | undefined
+
+function selectConversation(id: string) {
+  unreadConversationIds.value.delete(id)
+  emit('selectConversation', id)
+}
 
 function openSingleConversation(event: MouseEvent, group: CodingConversationGroup) {
   if (group.conversations.length !== 1) return
   event.preventDefault()
-  emit('selectConversation', group.conversations[0].id)
+  selectConversation(group.conversations[0].id)
 }
 
 const query = ref('')
 const conversationList = ref<HTMLElement | null>(null)
 const codingGroups = computed(() => groupCodingConversations(props.conversations, query.value))
+const runningConversationIds = computed(() => new Set(props.runningConversationIds ?? []))
 const projectGroups = computed(() => codingGroups.value.filter(group => !group.temporary))
 const temporaryGroup = computed(() => codingGroups.value.find(group => group.temporary) ?? null)
 const codingContext = computed(() => showsCodingHistory(props.activeSection))
 const ctfContext = computed(() => props.activeSection === 'ctf')
 const vulnContext = computed(() => props.activeSection === 'vuln')
+
+watch(
+  () => props.runningConversationIds ?? [],
+  (ids) => {
+    const next = new Set(ids)
+    if (observedRunningIds) {
+      for (const id of observedRunningIds) {
+        if (!next.has(id) && id !== props.activeConversationId) {
+          unreadConversationIds.value.add(id)
+        }
+      }
+    }
+    observedRunningIds = next
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.activeConversationId,
+  (id) => {
+    if (id) unreadConversationIds.value.delete(id)
+  },
+)
 
 watch(
   () => [props.activeConversationId, codingContext.value, codingGroups.value.length] as const,
@@ -184,15 +220,23 @@ watch(
               class="coding-project-group"
             >
               <summary
-                class="coding-project-row flex cursor-pointer list-none items-center gap-2 rounded-md px-3 py-1.5 font-medium hover:bg-accent/50"
+                class="coding-project-row group flex cursor-pointer list-none items-center gap-2 rounded-md px-3 py-1.5 font-medium hover:bg-accent/50"
                 :title="group.paths.length ? group.paths.join('\n') : group.name"
                 @click="openSingleConversation($event, group)"
               >
                 <Folder class="size-4 shrink-0 text-muted-foreground" />
                 <span class="min-w-0 flex-1 truncate">{{ group.name }}</span>
-                <span class="coding-project-count font-normal tabular-nums text-muted-foreground">
-                  {{ group.conversations.length }}
-                </span>
+                <Button
+                  v-if="group.path"
+                  variant="ghost"
+                  size="icon-sm"
+                  class="coding-project-new-session shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                  :aria-label="`在 ${group.name} 中新建会话`"
+                  :title="`在 ${group.name} 中新建会话`"
+                  @click.stop="$emit('newProjectSession', group.path)"
+                >
+                  <Plus class="size-3.5" />
+                </Button>
               </summary>
               <!-- Child title starts under the folder name (right of the folder icon). -->
               <div class="coding-project-children mt-0.5 space-y-0.5">
@@ -208,8 +252,14 @@ watch(
                     size="sm"
                     class="coding-project-row coding-project-child h-7 min-w-0 flex-1 justify-start"
                     :aria-current="activeConversationId === conversation.id ? 'true' : undefined"
-                    @click.stop="$emit('selectConversation', conversation.id)"
+                    @click.stop="selectConversation(conversation.id)"
                   >
+                    <AkLoadingMark v-if="runningConversationIds.has(conversation.id)" label="运行中" />
+                    <span
+                      v-else-if="unreadConversationIds.has(conversation.id)"
+                      class="coding-session-complete size-1.5 shrink-0 rounded-full bg-primary"
+                      aria-label="有新消息"
+                    />
                     <span class="truncate">{{ conversation.title }}</span>
                   </Button>
                   <Button
@@ -239,9 +289,6 @@ watch(
               @click="openSingleConversation($event, temporaryGroup)"
             >
               <span class="min-w-0 flex-1 truncate">{{ temporaryGroup.name }}</span>
-              <span class="coding-project-count font-normal tabular-nums text-muted-foreground">
-                {{ temporaryGroup.conversations.length }}
-              </span>
             </summary>
             <div class="coding-project-children mt-0.5 space-y-0.5">
               <div
@@ -256,8 +303,14 @@ watch(
                   size="sm"
                   class="coding-project-row coding-project-child h-7 min-w-0 flex-1 justify-start"
                   :aria-current="activeConversationId === conversation.id ? 'true' : undefined"
-                  @click.stop="$emit('selectConversation', conversation.id)"
+                  @click.stop="selectConversation(conversation.id)"
                 >
+                  <AkLoadingMark v-if="runningConversationIds.has(conversation.id)" label="运行中" />
+                  <span
+                    v-else-if="unreadConversationIds.has(conversation.id)"
+                    class="coding-session-complete size-1.5 shrink-0 rounded-full bg-primary"
+                    aria-label="有新消息"
+                  />
                   <span class="truncate">{{ conversation.title }}</span>
                 </Button>
                 <Button
@@ -350,11 +403,6 @@ watch(
   letter-spacing: var(--text-control--letter-spacing);
 }
 
-.coding-project-count {
-  font-size: var(--text-control);
-  line-height: var(--text-control--line-height);
-  letter-spacing: var(--text-control--letter-spacing);
-}
 
 /*
  * Align nested task titles with the folder name column:

--- a/app/src/composables/useConversations.ts
+++ b/app/src/composables/useConversations.ts
@@ -563,6 +563,7 @@ export function useConversations() {
   const activeRunning = computed(() => (
     activeId.value ? runningIds.value.has(activeId.value) : false
   ))
+  const runningConversationIds = computed(() => [...runningIds.value])
   const activeAborting = computed(() => (
     activeId.value ? abortingIds.value.has(activeId.value) : false
   ))
@@ -1698,6 +1699,7 @@ export function useConversations() {
     active,
     workspacePath,
     activeRunning,
+    runningConversationIds,
     activeAborting,
     activeMessageQueue,
     selectedModelMode,


### PR DESCRIPTION
This pull request introduces several improvements to the coding project and conversation management UI, focusing on enhancing project switching, session creation, and user notifications for completed background tasks. The changes add new dropdown-based project selection in the chat composer, enable quick creation of new sessions within projects, and provide visual reminders for background session completions. The sidebar and context sidebar components are updated to support these features, and related tests are added or updated.

**Project and Conversation Management Enhancements:**

* Added a dropdown menu to the chat composer (`ChatComposer.vue`) that allows users to quickly switch between coding projects or create a new project session directly from the composer. This uses the new `projectOptions` prop and emits `chooseProject` and `chooseWorkspaceForNewTask` events. [[1]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R132) [[2]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R159-R160) [[3]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R1701-R1731)
* Updated the main app logic (`App.vue`) to compute available coding projects, handle project selection and new session creation, and propagate these actions through new event handlers and props. [[1]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R19) [[2]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R85-R87) [[3]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R320-R330) [[4]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R639) [[5]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R675)

**Sidebar and Context Sidebar Improvements:**

* Enhanced the `AppSidebar.vue` and `ContextSidebar.vue` components to support session creation within projects via a hover-only plus button, propagate running conversation IDs, and emit new events for project session creation. [[1]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R14) [[2]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R31) [[3]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R73-R79) [[4]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daR35) [[5]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daR45-R95) [[6]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daL187-R239)
* Implemented visual reminders in the context sidebar for background sessions that have completed, using unread indicators and tracking running conversation IDs. [[1]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daR45-R95) [[2]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daL211-R262)

**Testing:**

* Added and updated tests in `AppSidebar.test.ts` to verify the new session creation button, the hover-only plus action, and the completion reminder for background sessions.

**Prop and Event Propagation:**

* Updated prop and event signatures across `ChatPage.vue`, `ChatComposer.vue`, and related components to support the new project selection and session creation features. [[1]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R189) [[2]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R207) [[3]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R2059) [[4]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R2073-R2074)

These changes collectively provide a more streamlined and interactive experience for managing coding projects and conversations, especially for users working with multiple projects or background sessions.

**other**

救命啊为什么 MilkSU 不会 PGP 签名提交啊神秘 root 用户吗我去，我哭了啊😭😭😭😭😭

**References:**
- [[1]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R132) [[2]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R159-R160) [[3]](diffhunk://#diff-7a1f5332767feecaaa00fb17269bee2570503d38f2ed6c690a976cb4ff1c87b9R1701-R1731)
- [[1]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R19) [[2]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R85-R87) [[3]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R320-R330) [[4]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R639) [[5]](diffhunk://#diff-12547a84bf202040b65812db58c16a324313390180fb3cbb9bed08b1038055a3R675)
- [[1]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R14) [[2]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R31) [[3]](diffhunk://#diff-a1487a61f877ffe734a9055f4c7c9ccc053c641d6b051ad61f1f1b7578260cd5R73-R79) [[4]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daR35) [[5]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daR45-R95) [[6]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daL187-R239) [[7]](diffhunk://#diff-55442330b2c9874a4a62d95deca76c805e4bb4873b9bcc5a84eb111feb7016daL211-R262)
- [app/src/components-vue/AppSidebar.test.tsR192-R263](diffhunk://#diff-d668507a7a8e6b232c2661b2b3dcfedc39346b5c70164c7a24868850eab91cbaR192-R263)
- [[1]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R189) [[2]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R207) [[3]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R2059) [[4]](diffhunk://#diff-80cd8720c868bdd18b726661457f238be170a4caab4ef8d393512670c2e352d2R2073-R2074)