### PR TITLE
fix(build): restore frontend typecheck

### DIFF
--- a/app/src/components-vue/CTFDebrief.test.ts
+++ b/app/src/components-vue/CTFDebrief.test.ts
@@ -156,7 +156,7 @@ describe('CTFDebrief contribution evidence', () => {
     expect(writeText).toHaveBeenCalledOnce()
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('MilkSU CTF 复盘接力棒'))
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('Judge：Accepted'))
-    expect(writeText.mock.calls[0]?.[0]).not.toContain('不能写成用户独立能力事实')
+    expect(writeText).toHaveBeenCalledWith(expect.not.stringContaining('不能写成用户独立能力事实'))
     expect(host.textContent).toContain('已复制')
   })
 

--- a/app/src/components-vue/ChatPage.vue
+++ b/app/src/components-vue/ChatPage.vue
@@ -2564,7 +2564,7 @@ watch(
               {{ mcpConfig.problem }}
             </p>
 
-            <div v-else class="mt-2 space-y-2">
+            <div v-else-if="mcpConfig" class="mt-2 space-y-2">
               <CodingMCPReviewCard
                 v-for="server in mcpConfig.servers"
                 :key="server.name"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milksu-desktop",
-  "version": "26.819.1",
+  "version": "26.822.1",
   "private": true,
   "description": "MilkSU Chromium desktop shell",
   "main": "main.cjs",

--- a/docs/architecture/current-system.md
+++ b/docs/architecture/current-system.md
@@ -286,7 +286,7 @@ GitHub-only 模式不生成 updater ZIP 或元数据；显式选择 OTA 上传�
 CI 通过 rclone 把 ZIP、DMG 和元数据写到私有 R2 的不可变版本路径，逐个回读校验 SHA-256，再用窄
 publisher token 在 Admin 建草稿；管理员发布后，已登录且访问正常的 Stable 客户端才可经 Worker 获取
 feed 和安装包。R2 没有公共下载地址，账户 Bearer token 只由 Electron 主进程持有。正式内测发行基线是
-`v26.819.1 / eed1dac28a82453bf0a73b146a0416e961de46d9`。仓库版本号是 `26.819.1`。
+`v26.819.1 / eed1dac28a82453bf0a73b146a0416e961de46d9`。仓库开发版本号是 `26.822.1`；它尚无新的发行回执。
 文档收口提交不改变该 tag，不能把后续 HEAD 写成已发版。打包后的
 Go Runtime 以自身所在 `resources` 目录直接定位同级 `milksu-sidecar/node.exe` 与 `chat-bridge.cjs`，
 不再把开发仓库根定位混入安装版资源查找。macOS

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -31,7 +31,7 @@
 | 阶段 | **内测迭代 / Agent Runtime 与跨平台发行收敛**。当前工作不再按 M3/M4 里程碑组织。 |
 | 历史基线 | M3 product-loop 已在 `108e0e3`（2026-08-05）合并，仅供追溯。 |
 | 正式发行基线 | `v26.819.1 / eed1dac28a82453bf0a73b146a0416e961de46d9`（2026-08-19 今日首发）。这是最近一次带 SHA-256 与三端产物的内测发行；GitHub prerelease 提供带版本号的 DMG、EXE、DEB 与 `SHA256SUMS`；R2/Admin current pointer 未发布。 |
-| 开发版本线 | 根目录与 `desktop/package.json` 是 `26.819.1`。发行源是 `eed1dac`；之后只有文档收口提交，不移动该 tag。 |
+| 开发版本线 | 根目录与 `desktop/package.json` 是 `26.822.1`。正式发行源仍是 `eed1dac`；当前本地开发构建不移动该 tag，也不构成新的发行回执。 |
 | 当前开发 | 今日首发已发出。下一轮继续用这个安装包做 Agent GUI / Pi Runtime 回归，不要把文档提交写成新包。 |
 | 平台边界 | `26.819.1`：macOS DMG 本机 Developer ID 签名并公证；Windows 安装器完成原生 Runtime 与首次启动但未代码签名，并打入审阅过的 CUA Driver；Linux DEB 完成包结构、Sidecar、Go Runtime 与 Xvfb Electron 启动，仍无 Secret Service、本地 OCR、Computer Use。 |
 | 发行流水 | 下一发行从干净、已推送的 `main` 对 canonical Go/Vue/Sidecar/lint/生产与文档构建只验证一次；Windows/Linux 走云端，macOS 默认本机 `release:mac:local`。必须创建 GitHub Release 页并上传带版本号的 DMG/EXE/DEB 与 SHA256SUMS，不能只留空 tag。GitHub-only 不生成 OTA ZIP/metadata。 |

--- a/docs/developer/document-status.md
+++ b/docs/developer/document-status.md
@@ -25,7 +25,7 @@
 | --- | --- |
 | 正式发行基线 | `v26.819.1 / eed1dac28a82453bf0a73b146a0416e961de46d9`（2026-08-19 今日首发）。这是最近一次带三端产物与 SHA-256 的内测包；标签固定在该 source commit，后续 workflow/文档提交不移动标签。 |
 | 已发行线 | `26.817.1` 建立账户 TokenFlux / 双来源路由与 Pi 网页查证；`26.817.2` 补齐 Linux 试用 DEB 与 Windows 启动；`26.817.3` 修 Windows 账户授权恢复与打包 Sidecar 路径；`26.818.1` 发出账户可调用目录与当日首发包；`26.818.2` 发出 Coding 多标签浏览器、`milksu_workspace`、85% 自动压缩、CTF 本地目录、Windows Computer Use 与应用级调试模式；`26.819.1` 发出 ak-ui 生产视觉、目录不默认展开，以及普通 Go 不再自动启动隔离浏览器。 |
-| 开发版本线 | 仓库版本为 `26.819.1`。发行源是 `eed1dac`；之后只有文档收口提交，不移动该 tag。 |
+| 开发版本线 | 仓库版本为 `26.822.1`。正式发行源仍是 `eed1dac`；当前本地开发构建不移动该 tag，也不构成新的发行回执。 |
 | 三端内测发行 | GitHub prerelease `v26.819.1` 已提供签名并公证的 macOS ARM64 DMG、未签名 Windows x64 EXE 和 Linux x64 试用 DEB，以及 `SHA256SUMS-26.819.1.txt`；R2/Admin current pointer 未发布。 |
 | Linux | `26.819.1` DEB 已包含当时的 Pi Runtime 收敛并通过原生 Ubuntu 包结构、Node/Pi、Go Runtime 与 Xvfb Electron 启动；仍不含 Secret Service、本地 OCR 或 Computer Use。 |
 | Agent Harness | Pi 拥有 Session、Compaction、自然语言理解、通用文件/Shell 与 Tool Loop。MilkSU 已删除 workspace-only 文件工具、Node 文件权限状态机、普通回合 watchdog、CTF sandbox-exec、CVE 只读启动限制与客服式回复模板。不扫描用户句子做关键词/正则意图路由。 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@milksu/milksu",
-  "version": "26.819.1",
+  "version": "26.822.1",
   "description": "MilkSU — one-stop cybersecurity AI learning client",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the development version of MilkSU from `26.819.1` to `26.822.1` across the codebase and documentation, clarifying that the new version is for local development only and does not constitute a new official release. Additionally, it includes a minor UI logic fix and a test improvement.

**Version bump and documentation updates:**

* Updated the version in `package.json` and `desktop/package.json` from `26.819.1` to `26.822.1` to reflect ongoing development. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-070ef7659160d7a5d6678b3736e57b45a08caf60f3ceee146e6f7027292de0f7L3-R3)
* Updated documentation files (`docs/developer/current-objectives.md`, `docs/developer/document-status.md`, `docs/architecture/current-system.md`) to reference `26.822.1` as the current development version, clarifying that the release tag remains at `eed1dac` and no new official release has been made. [[1]](diffhunk://#diff-71a912f94609c6a09d1135ee69a012b63705c3c8faea953e5c5b68343af914d4L34-R34) [[2]](diffhunk://#diff-5bc8d718ba0cd7ce3212efe94140a9bf447205674c65fb21a31a934b72e2f0a4L28-R28) [[3]](diffhunk://#diff-a2336177cd1baf7b3485e06d544211d44c7bb73296fffe36cca4e5db55967103L289-R289)

**UI and test improvements:**

* Fixed a logic bug in `ChatPage.vue` to ensure the review card section only renders when `mcpConfig` is defined.
* Improved test assertion style in `CTFDebrief.test.ts` for clarity and correctness.