### PR TITLE
设计与开发：子 Agent 结构化回传与活状态

### DIFF
--- a/docs/developer/loop-subagent-yield.md
+++ b/docs/developer/loop-subagent-yield.md
@@ -48,3 +48,25 @@ Advisor 窗、OMP Agent Hub 全套 IRC、默认打开更多子 Agent 类型、�
 ## 删除路径
 
 关掉 schema 校验则回散文回传；拿掉名单组件；`subagent` 工具仍可按现状调用。
+
+## 基线实测（当前架构，未实现本切片）
+
+机器：macOS darwin arm64，Node v26.0.0，Pi 0.84.1，`pi-sub-agent` 已打包进 Sidecar。时间：2026-08-25T10:25:13Z。命令：`node --test sidecar/pi/loop-baseline-subagent.test.js`（2 通过）。`pi-subagent-runner.test.cjs` 本机通过。
+
+构造：
+
+1. 读 `node_modules/pi-sub-agent/extensions/index.ts` 的 `SingleResult`。
+2. 调 `projectToolModelUsage`，喂一条假的 `details.results[]`。
+3. 搜 Vue：没有子任务名单组件。
+
+`SingleResult` 实机字段：`agent`、`agentSource`、`task`、`exitCode`、`messages`、`stderr`、`stdout`、`usage`、`model`、`step`。
+
+| 项 | 当前架构 |
+| --- | --- |
+| 父模型看到的 | Markdown 文本（超限从 **尾** 截，50KB/2000 行） |
+| `files[]` | **无** |
+| `findings[]` | **无** |
+| MilkSU 用量投影 | 只读 `exitCode` / `model` / usage |
+| 活状态 UI | **无** |
+
+**Summary：** 父 Loop 不能按字段取「改了哪些文件」。产品里也看不见子任务在跑。隔离与 runner 在本机是绿的，缺的是 schema yield 和名单面。本切片的缺口在实机类型和前端上都成立。

--- a/docs/developer/loop-subagent-yield.md
+++ b/docs/developer/loop-subagent-yield.md
@@ -1,0 +1,50 @@
+# Loop 切片：子 Agent 结构化回传与活状态
+
+> 文档状态：**Target / Not implemented**
+>
+> 选定范围：父 Loop 的 `subagent` 工具如何收回结果，以及人如何看见子任务还在不在跑。继续用现有 Pi 子进程 + writer worktree，不造第二套 harness。
+>
+> 缺什么：父侧拿到散文；产品里没有子任务名单（id / 状态 / 结束码 / yield）。
+
+## 目标
+
+- 子 Agent 结束必须交出可校验 schema（至少：`status`、`cwd` 或 worktree id、`files[]`、`findings[]`、`exitCode`）。父 Loop 当 `tool_result` 字段用，不靠再理解一段话。
+- 只读角色（planner / reviewer / scout / security-auditor）与 writer worktree 角色保持现有隔离；schema 不让只读子 Agent 变成可写。
+- 产品上给一个 **名单/状态面**（环境栏或工具组，不是第二条聊天）：id、角色、状态、耗时、结束码；点开看 yield。这是本切片的测试操作面，也是以后只 steer 某一个子任务的入口。
+- 父会话停止仍要停子进程。
+
+## 现状
+
+`subagent` 已在 Coding 工具表里；effectful 子进程有 worktree 与模型改写。回传是自然语言。前端几乎不投影子任务活状态（用量里只在结束后拆 usage）。没有这个面就无法稳定测「父 Agent 有没有读到字段」。
+
+## 测试方式
+
+1. **Schema 单测**  
+   合法 yield 通过；缺字段失败；只读子 Agent 带写入路径必须拒绝。
+2. **父 Loop 夹具**  
+   子 Agent 交 `{ files: ["a.ts"], findings: [{ path: "a.ts", note: "renamed" }] }`。断言父模型在 **零次额外工具** 下能报出 `files[0]`（假 Provider 脚本直接读 tool_result，不依赖真模型发挥）。
+3. **生命周期**  
+   跑 / 停 / 成功 / 失败；父 abort 杀掉子进程；writer 不得改主会话 cwd。
+4. **Vue**  
+   名单在子任务 start 时出现，结束时变成成功/失败；空名单不画空卡片或「还没有子任务」说明（空白 + 控件自己的标签）。中英 `t()` 成对。视觉走现有事实面（工具组或环境栏），不新造一种卡片。
+
+## 验收标准
+
+- [ ] 假 Provider：父侧 tool_result 含约定字段，测试断言路径取值，不解析散文。
+- [ ] 只读 vs writer 隔离回归（现有 `bridge-policy` / `pi-subagent-runner` 测试仍过）。
+- [ ] 父 abort ⇒ 子进程退出（有测试，不只注释）。
+- [ ] UI：至少一个活状态名单；设计语言合同覆盖该组件；无第二条对话、无空状态教练文案。
+- [ ] 不把子 Agent 的 Key、绝对本机家目录或 relay 凭据写进 yield。
+- [ ] 不把「有按钮」写成「父 Loop 已会用字段」；Loop 完成以夹具取字段为准。
+
+## 非目标
+
+Advisor 窗、OMP Agent Hub 全套 IRC、默认打开更多子 Agent 类型、替换 `pi-sub-agent`。
+
+## UI
+
+环境栏或工具活动组里的子任务名单。需要过设计语言五层：材质/壳/列表指挥面不新增；这是事实面。
+
+## 删除路径
+
+关掉 schema 校验则回散文回传；拿掉名单组件；`subagent` 工具仍可按现状调用。

--- a/sidecar/pi/loop-baseline-subagent.test.js
+++ b/sidecar/pi/loop-baseline-subagent.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { projectToolModelUsage } from "./bridge-usage-view.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("baseline: pi-sub-agent details have no files[] or findings[] schema", async () => {
+  const source = await readFile(
+    join(root, "node_modules/pi-sub-agent/extensions/index.ts"),
+    "utf8",
+  );
+  assert.match(source, /interface SingleResult/);
+  assert.match(source, /exitCode: number/);
+  assert.match(source, /messages: RawMessage\[\]/);
+  assert.equal(source.includes("files[]"), false);
+  assert.equal(/findings\s*:/.test(source), false);
+});
+
+test("baseline: MilkSU usage projection only reads exitCode and model from results", () => {
+  const records = projectToolModelUsage({
+    details: {
+      results: [{
+        model: "grok-4.6",
+        exitCode: 0,
+        usage: { inputTokens: 10, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      }],
+    },
+  }, { toolName: "subagent", conversationId: "c1", toolCallId: "t1" });
+  assert.equal(records.length, 1);
+  assert.equal(records[0].success, true);
+  assert.equal(records[0].files, undefined);
+});


### PR DESCRIPTION
## 目标

子 Agent 结束交出可校验 schema（至少 `status`、cwd/worktree id、`files[]`、`findings[]`、`exitCode`）。父 Loop 当 `tool_result` 字段用，不解析散文。只读角色与 writer worktree 隔离不变。父会话停止仍停子进程。

产品给一个 **名单/状态面**（环境栏或工具组，不是第二条聊天）：id、角色、状态、耗时、结束码，点开看 yield。这既是测试操作面，也是以后只引导某一个子任务的入口。

继续用现有 Pi 子进程 + writer worktree，不造第二套 harness。

切片合同：`docs/developer/loop-subagent-yield.md`

## 测试方式

1. Schema 单测：合法通过；缺字段失败；只读子 Agent 带写入路径拒绝。
2. 父 Loop 夹具：子 Agent 交固定 JSON。父侧 **零次额外工具** 能取出 `files[0]`（假 Provider 读 tool_result）。
3. 生命周期：跑/停/成功/失败；父 abort 杀子进程；writer 不改主会话 cwd。
4. Vue：start 出现名单，结束变成功/失败；无空状态教练文案；中英成对；视觉合同覆盖该组件。

## 验收标准

- 假 Provider：tool_result 含约定字段，测试按路径取值。
- 只读 vs writer 的现有 policy / runner 测试仍过。
- 父 abort ⇒ 子进程退出（有测试）。
- 至少一个活状态名单；不是第二条对话。
- 不把 Key、家目录、relay 凭据写进 yield。
- 「有按钮」不等于 Loop 完成；Loop 完成以夹具取字段为准。

## 非目标

Advisor 窗、OMP Agent Hub 全套、替换 `pi-sub-agent`。
