### PR TITLE
feat(desktop): send current version on Admin update polls

### DIFF
--- a/desktop/update-manager.cjs
+++ b/desktop/update-manager.cjs
@@ -192,7 +192,7 @@ class UpdateManager {
 
   async fetchLatest(token) {
     const response = await this.fetchImpl(
-      `${this.apiUrl}/v1/releases/latest?channel=stable&platform=${encodeURIComponent(this.platform)}&arch=${encodeURIComponent(this.arch)}`,
+      `${this.apiUrl}/v1/releases/latest?channel=stable&platform=${encodeURIComponent(this.platform)}&arch=${encodeURIComponent(this.arch)}&current=${encodeURIComponent(this.currentVersion)}`,
       {
         headers: {
           authorization: `Bearer ${token}`,

--- a/desktop/update-manager.test.cjs
+++ b/desktop/update-manager.test.cjs
@@ -99,6 +99,21 @@ test('checks and downloads updates with a main-process authorization header', as
   assert.equal(manager.view().state, 'idle')
 })
 
+test('reports the running version when polling Admin for the latest release', async () => {
+  let polled = ''
+  const manager = new UpdateManager(managerOptions({
+    fetchImpl: async (url) => {
+      polled = String(url)
+      return jsonResponse(404, { release: null })
+    },
+  }))
+  assert.equal((await manager.check()).state, 'idle')
+  assert.match(polled, /\/v1\/releases\/latest\?/)
+  assert.match(polled, /platform=darwin/)
+  assert.match(polled, /arch=arm64/)
+  assert.match(polled, /current=0\.1\.0/)
+})
+
 test('does not contact the feed or expose a prompt without an active account token', async () => {
   let fetches = 0
   const manager = new UpdateManager(managerOptions({


### PR DESCRIPTION
## Summary
- Authenticated `/v1/releases/latest` checks now include `current=<app version>`.
- Admin already records platform/arch from 26.827.1 polls; this fills the running version on the next packaged build.
- Not a GitHub Release. No updater ZIP change.

## Test plan
- [x] `node --test desktop/update-manager.test.cjs`
- [ ] After the next official package, Admin user dossiers show 当前版本.