### PR TITLE
按 Pi 渐进披露收束产品工具提示，不改 MCP/Skills 配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,12 +179,22 @@ mechanism or proven design, and only then write the smallest MilkSU-owned implem
 earlier level was insufficient. “Mature” requires an inspectable source, compatible license, bounded
 permissions, maintained releases and evidence for the relevant use case; popularity alone is insufficient.
 Do not grow a second generic Coding Agent harness when an upstream component already owns the capability.
-When Pi Agent Harness already exposes a reviewed session API, lifecycle hook, extension point, tool,
+When the selected Agent Harness already exposes a reviewed session API, lifecycle hook, extension point, tool,
 compaction mechanism, runtime-context mechanism or other matching primitive, integrate through that
-primitive and preserve Pi's semantics instead of recreating the behavior with MilkSU-owned prompt routing,
+primitive and preserve that harness's semantics instead of recreating the behavior with MilkSU-owned prompt routing,
 regular expressions, parallel state machines or a second harness. MilkSU should add only the product UI,
-desktop authorization, persistence and evidence projection that Pi does not own; document the concrete Pi
-gap before admitting a replacement mechanism.
+desktop authorization, persistence and evidence projection that the harness does not own; document the concrete
+harness gap before admitting a replacement mechanism.
+
+Progressive disclosure follows the currently selected Agent Harness core. Today that core is Pi
+(`pi-coding-agent` 0.84.1): Skill catalogs stay at `name` + when-to-use `description`, bodies load with
+`read` or `/skill:name`, slash-only skills use `disable-model-invocation`, and fat optional tools
+`registerTool` first then activate through the harness (Pi Dynamic Tool Loading or a typed product action).
+Do not add a MilkSU-owned injector that keyword-scans user text, pastes Skill bodies or tool-action essays
+into the system prompt, or guesses when to inject context. If the selected core later becomes another
+reviewed harness (for example DeepSeek Harness), use that harness's native skill and tool disclosure and
+drop Pi-specific prompt leftovers; do not keep a MilkSU disclosure adapter that tries to look the same on
+every harness.
 
 ## Non-Negotiable Boundaries
 
@@ -226,6 +236,11 @@ deferred to one destructive pre-release consolidation after the product slices a
 
 ## Agent Intent and Product UI Tools
 
+- Progressive disclosure is owned by the selected Agent Harness, not by MilkSU prompt routing.
+  For the current Pi core: put when-to-use on the Skill or tool `description`; do not repeat it as a
+  system-prompt MUST essay; do not paste Skill bodies into the system prompt. If the core changes
+  (for example to DeepSeek Harness), follow that core's disclosure instead of copying Pi's catalog
+  format or keeping a MilkSU injector.
 - Do not scan user text with keywords or regular expressions to decide which tool, tab, page or
   approval to run. The model understands natural language. GUI one-click actions send a typed
   product action. Isolated browser starts because the user opens the rail or the model

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -157,6 +157,8 @@
 
 文档收口提交不移动该 tag。Admin current pointer 尚未由维护者发布；Windows 代码签名、Linux Secret Service / 本地 OCR、Hyprland/Xorg Computer Use 仍缺。#39 rewind/handoff、CTF 比赛模式和实验室红队学习面仍未接线。
 
+- Coding / CTF / CVE / 实验室会话不再把 `milksu_ask` / `milksu_progress` / workspace 动作表和 Pi `tool_result` 截断说明重复写进 system prompt。when-to-use 只留在工具 description 与 Pi Skill 名录。`release-milksu` 设 `disable-model-invocation: true`，`/skill:release-milksu` 仍可用。不改 MCP 加载、`activeTools` 或 Settings 的 Skills 配置面。依据见 [research-progressive-disclosure.md](research-progressive-disclosure.md)。
+
 ## 当前产品事实
 
 ### Pi Runtime 收敛

--- a/docs/developer/document-status.md
+++ b/docs/developer/document-status.md
@@ -2,7 +2,7 @@
 
 > 状态：Current / Living
 >
-> 最后事实审计：2026-09-04
+> 最后事实审计：2026-09-05
 >
 > 产品开发目标：内测迭代 / Agent Runtime 与跨平台发行收敛
 
@@ -29,7 +29,7 @@
 | 许可证 | 主项目为 `AGPL-3.0-only`（`LICENSE` / `NOTICE`）。第三方仍保留原许可。Obelisk 作为计划嵌入的 AGPL 记忆组件与此兼容；尚未 vendored。 |
 | 三端正式发行 | GitHub Latest Release `v26.904.1` 已提供签名并公证的 macOS ARM64 DMG、未签名 Windows x64 EXE、Linux x64 DEB 与 x64 tar.gz，以及 `SHA256SUMS-26.904.1.txt`。OTA 草稿应已上传私有 R2；Admin current pointer 仍须维护者在「版本」页发布。 |
 | Linux | `26.904.1` 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball；GNOME Wayland Computer Use 走 Portal。仍无 Secret Service、本地 OCR；Hyprland / Xorg Computer Use unavailable。ISSUE #19 已关闭（拒绝 X11 xinput）。合同见 [Linux 安装与桌面合同](linux-platform-support.md)。 |
-| Agent Harness | Pi 拥有 Session、Compaction、自然语言理解、通用文件/Shell 与 Tool Loop。MilkSU 已删除 workspace-only 文件工具、Node 文件权限状态机、普通回合 watchdog、CTF sandbox-exec、CVE 只读启动限制与客服式回复模板。不扫描用户句子做关键词/正则意图路由。`26.823.1` 起 Coding/CTF/CVE/实验室共用完整 Coding loop（含压缩、终端、Git、浏览器、LSP、Goal），领域工具叠在上面而不是替换；工具结果进模型前截断到 Pi 的 50KB/2000 行。 |
+| Agent Harness | Pi 拥有 Session、Compaction、自然语言理解、通用文件/Shell 与 Tool Loop。MilkSU 已删除 workspace-only 文件工具、Node 文件权限状态机、普通回合 watchdog、CTF sandbox-exec、CVE 只读启动限制与客服式回复模板。不扫描用户句子做关键词/正则意图路由。`26.823.1` 起 Coding/CTF/CVE/实验室共用完整 Coding loop（含压缩、终端、Git、浏览器、LSP、Goal），领域工具叠在上面而不是替换；工具结果进模型前截断到 Pi 的 50KB/2000 行。未发版：产品工具 when-to-use 不再在 system prompt 复述一遍；`release-milksu` 对模型名录隐藏。 |
 | 上下文工程 | `26.825.1` 把经监督器校验的主会话 cwd 明确注入 Pi；writer worktree 仅属于独立 effectful subagent。Sidecar 通过 Pi 原生长缓存保留复用稳定会话前缀，压缩仍禁用一次性缓存写入。`26.904.1` 起窗口优先级为手动覆盖 > catalog（忽略 `128000` 占位）> 型号族预设 > 保守默认；Composer 环按 Pi 组装分类，并落地 edit 锚点、`tool_result` bound、中途引导与子 Agent 结构化回传。GPT 与 Claude Opus / Sonnet / Fable 使用思考档位预设，其他模型在设置中手动声明；Composer 的对话级离散滑块只显示标准英文档位，经 Go 约束后调用 Pi 原生档位，最高为 `max`，子 Agent 同步继承。自动化已通过，真实 Provider 缓存命中率与 effort 请求仍待用户授权的计费链路验收。 |
 | MilkSU 宿主边界 | 只保留会话目录记录、Provider 凭据隔离、桌面授权、领域事实/Judge，以及危险大目录删除二次确认。Coding 另有类型化 `milksu_workspace` 与对话级批准，不替代 Pi 工具循环。 |
 | 模型与附件 | 账户 TokenFlux 与本机 Provider 共用可调用模型目录；图片由当前模型原生 image input 或本地 OCR 自动路由，附件通过统一可预览/移除队列进入 Pi。 |

--- a/docs/developer/research-harness-ablation.md
+++ b/docs/developer/research-harness-ablation.md
@@ -1,0 +1,85 @@
+# 研究：Pi 之上的 MilkSU harness 消融
+
+> 文档状态：**Historical / Research**。不是产品完成线，也不是实现队列。
+>
+> 日期：2026-09-05。模型：`deepseek/deepseek-v4-flash`。种子：1。
+> 运行器：`spikes/harness-ablation/`（隔离 spike，不进生产链）。
+
+## 问题
+
+MilkSU 在 Pi Agent 之上还包了哪些层？其中哪些对文件型 Coding 任务是多余的，会不会把解题率做差？
+
+## 方法
+
+同一模型、同一组独立 Judge 任务，只改 MilkSU 附加层：
+
+| 变体 | 模型看到的附加物 |
+| --- | --- |
+| `pi_native` | Pi 默认提示 + 文件/Shell 工具 |
+| `host_facts` | + OS/arch/shell + 权威 cwd |
+| `product_ui` | + `milksu_progress` / `milksu_ask` / `milksu_workspace` 及其 MUST 文案 |
+| `current_coding` | 接近现行 Coding：完整 runtime 政策、产品工具、常驻目录 stub、已审阅 Skill 名 |
+
+`milksu_ask` 在 runner 里自动点第一项，避免挂起；产品里这一步会暂停回合等用户点选。Token 估计用 Pi 的 chars/4。`current_coding` 的 goal/LSP/web/subagent schema 是短 stub，**低估**真实目录体积。
+
+## 静态体积（用户还没说话）
+
+现行 Coding 附加层合计约 **3627** token。其中看起来最像空转税的是：
+
+| 层 | 约 token | 本轮文件任务里有没有被用到 |
+| --- | ---: | --- |
+| 已审阅 Skill 名录（7 个 description） | 1106 | 无 |
+| `milksu_workspace` schema + 长 guidance | 1061 | 无 |
+| 常驻目录 stub（goal / bg / web / lsp / subagent） | 390+（真实 schema 更大） | 无 |
+| runtime 政策（界面语言、现场证据） | 189 | 无 |
+| `milksu_ask` MUST 文案 + schema | 271 | `ask_trap` 才触发 |
+| `milksu_progress` MUST 文案 + schema | 215 | `json_names` 触发了 2 次 |
+| tool_result 截断提醒 | 58 | Pi 已经截断 |
+| 宿主 OS/cwd 事实 | 174 | 路径任务需要，本轮中性 |
+
+`host_facts` 只加 174 token。从 `pi_native` 到 `current_coding`，附加上下文大约从 0 升到 3600。
+
+## 现场结果
+
+易题 6 道 + 较难题 `quoted_csv` 1 道。独立 Judge（import / 文件内容），不是模型自述。
+
+| 变体 | 易题解题 | 较难 CSV | 产品工具空转 | billed input | 均时 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `pi_native` | 5/6 | 通过 | 0 | 12340 | 2.8s |
+| `host_facts` | 5/6 | 通过 | 0 | 12086 | 3.2s |
+| `product_ui` | 6/6 | 通过 | 1 次 ask | 23350 | 3.9s |
+| `current_coding` | 5/6 | 通过 | 1 ask + 2 progress | 30442 | 4.5s |
+
+唯一共同失败是 `multistep`：写出了 `result.txt=42`，但 `src/double.js` 不能被 Judge import。`product_ui` 这道过了，所以**不能**把失败算到附加层头上。
+
+## 结论
+
+在这组短文件任务、单一 flash 模型和 1 个种子上：
+
+1. **解题率没有被附加层做差。** 没有测到“错误率随 MilkSU 层数上升”。
+2. **测到的是税，不是更笨。** `current_coding` 的 billed input 约是裸 Pi 的 **2.5 倍**，均时约 **1.6 倍**。
+3. **最像多余的层**（本轮零调用或只产生空转）：
+   - 每回合注入的 `milksu_workspace` 长 schema / guidance；
+   - 默认铺开的 7 个 Skill description；
+   - 文件任务用不到的 goal / bg / web / lsp / subagent 常驻目录；
+   - 与 Pi `tool_result` bound 重复的截断说明。
+4. **会改行为、在产品里会伤自主循环的层**：
+   - `milksu_ask` 的 MUST 文案：用户说“先给我两个方案”时，裸 Pi 直接做完；带产品层会先停下来等选择卡。Runner 自动点选后仍做对，但真产品会中断回合。
+   - `milksu_progress` 的“多步必须发计划”：简单的 `json_names` 被叫了两次。Pi 已有 goal 工具；白皮名单也写过 progress 应只做投影。
+5. **应保留的薄层**：OS/shell/cwd 事实（174 token，解题率与裸 Pi 相同）、凭据/审批/路径边界、领域 Judge。这些不是第二套 harness。
+
+Agent Harness 的常见失败模式是把产品 UI 工具和长政策写进每一轮的 tool catalog / system prompt。模型多半仍会用 `read`/`edit`/`write` 完成文件活，但上下文被占满，并在“选项 / 计划 / 工作台”话术上多走空转。本轮证据支持“减税”，还不支持“这些层会把短任务做砸”。
+
+## 不能外推
+
+- 一种模型、一个种子、短任务。长 CTF / CVE、弱模型、或真实 `milksu_ask` 挂起，都可能更差。
+- 没有拆掉 Go 审批、没有跑 Cybench。
+- 常驻目录 schema 是 stub，真实 LSP/MCP/subagent 描述会更贵。
+
+## 复跑
+
+```bash
+npm run spike:harness-ablation:test
+npm run spike:harness-ablation:inventory
+MILKSU_SPIKE_PROVIDER=deepseek MILKSU_SPIKE_MODEL=deepseek-v4-flash npm run spike:harness-ablation
+```

--- a/docs/developer/research-progressive-disclosure.md
+++ b/docs/developer/research-progressive-disclosure.md
@@ -1,0 +1,94 @@
+# 研究：按需加载不该自造，应对齐 Agent Skills + Pi Dynamic Tools
+
+> 文档状态：**Historical / Research**。不是实现队列。
+>
+> 日期：2026-09-05。起因：消融里看到现行 Coding 附加层约 3600 token，
+> 其中 workspace / Skill 名录 / 常驻目录本轮零调用；同时又担心“不注入就永远不触发”。
+
+## 社区已经收敛的答案
+
+“注入多少才刚好”不是 MilkSU 要发明的旋钮。开源编码 Agent 在 2025–2026 收敛成两套标准，职责不同：
+
+| 对象 | 标准 | 始终在上下文里的 | 真正按需加载的 | 用户强制 |
+| --- | --- | --- | --- | --- |
+| 流程 / 长说明书（Skill） | [Agent Skills](https://agentskills.io/integrate-skills) | `name` + `description`（约 50–100 token / 个） | `SKILL.md` 正文；再按需 `read` references/scripts | `/skill:name` |
+| 可执行工具目录（MCP / 胖工具） | MCP progressive discovery + Anthropic `defer_loading` / Tool Search | 3–5 个高频核心工具 | 被搜到或被激活的 schema | GUI / 斜杠 / 类型化产品动作 |
+
+Claude Code、Pi、OpenAI Codex、Microsoft Agent Framework、OpenHands 的 Skill 层都走第一套。
+Anthropic Tool Search、MCP 客户端最佳实践、Pi `docs/extensions.md` 的 Dynamic Tool Loading 走第二套。
+
+**不要**再加第三套：按用户句子关键词决定注入哪段 system prompt / 哪组工具。MilkSU 已经禁止这种路由。OpenHands 的 `triggers` 关键词注入也不采用。
+
+## Pi 已经有的，不要重写
+
+钉住的 `pi-coding-agent@0.84.1` 已经实现两套：
+
+1. **Skill 渐进披露**（`formatSkillsForPrompt`，对齐 agentskills.io）  
+   系统提示只放 `<available_skills>` 的 name / description / location。  
+   说明原文：*Use the read tool to load a skill's file when the task matches its description.*  
+   Pi 自己承认：模型不一定会 `read`；补偿是 **更好的 description** 或 **`/skill:name`**，不是把正文再贴进 system prompt。  
+   `disable-model-invocation: true` 可从名录隐藏，只留斜杠。
+
+2. **动态工具加载**（`docs/extensions.md` § Dynamic Tool Loading）  
+   先 `registerTool` 全部，初始只 `setActiveTools` 一小撮；需要时**只增不减**地激活。  
+   Anthropic 4.5+ / OpenAI `gpt-5.4`+ 走原生 `defer_loading` + `tool_reference`，前缀缓存不破。  
+   其他模型退回“下一轮带上新激活的完整 schema”。  
+   官方例子就是 `search_tools` loader。Pi 写明：带 `promptSnippet` / `promptGuidelines` 的懒加载工具会重建 system prompt、打断缓存；懒工具应只靠 `description`。
+
+MilkSU 注释“`createAgentSession` 时没列入的工具以后加不进去”仍然成立：**定义必须先注册**。这和“全部激活并再写一遍 MUST 文案”不是一回事。隔离浏览器已经是正确范例：Playwright MCP 只在用户打开右栏或类型化动作后才进会话。
+
+## “不注入就永远不触发”在成熟实现里怎么处理
+
+社区不靠猜阈值，靠三条并行通道：
+
+1. **名录里的 routing description**（始终注入，但很短）  
+   写 *when to use*，带用户会说的触发语，不要写成摘要。坏例子：`Helps with PDFs.`  
+   好例子：`Extracts text and tables from PDFs. Use when working with PDF documents.`  
+   不触发 = description 太窄或太含糊，**改 description**，不要改成“把正文常驻”。
+
+2. **用户强制**  
+   `/skill:name`（Pi / Claude / Codex 都有）。  
+   MilkSU 已有更强的通道：GUI 类型化 product action（打开浏览器、选 Computer Use、点选择卡）。这比模型自己发现更可靠。
+
+3. **承认模型会漏**  
+   Pi 文档原文：*models don't always do this; use prompting or `/skill:name` to force it.*  
+   成熟实现接受偶发漏触发，用斜杠/按钮补；**不接受**把全文预加载当补偿。
+
+Anthropic 对工具目录的对称规则：高频 3–5 个工具**不要** `defer_loading`，否则模型会为了日常 `read`/`edit` 先搜一轮。
+
+## 对照：MilkSU 现在偏了哪里
+
+消融里贵的不是“注册了工具”，而是 **双重披露 + 全量激活**：
+
+| 层 | 成熟做法 | 现行 MilkSU |
+| --- | --- | --- |
+| Skill | 名录 ~50–100 tok / 个，正文 `read` | Pi 名录已在；但 7 个 description 合计约 1106 tok（偏长），且 `release-milksu` 对每个 Coding 会话可见 |
+| `milksu_workspace` | 一个工具 + 短 when-to-use；或 GUI 打开后再激活 | schema ≈ 711 tok **再加** `codingWorkspaceGuidance()` ≈ 350 tok，内容重复 |
+| `milksu_ask` / `milksu_progress` | 工具 description 说明何时用；桌面投影事件 | 工具已注册，**另外** system prompt MUST 再命令一次 |
+| LSP / ImageGen / CUA driver / 浏览器 MCP | 注册，默认不激活；类型化动作或 search 再打开 | 会话创建时写进 `codingWorkspaceAutoToolNames` 并 `setActiveTools` 全开 |
+| 宿主 OS / cwd | 始终注入（不是 Skill） | 正确，应保留 |
+
+白皮名单里的 disposition 已经和社区一致：`milksu_progress` 只做投影，计划语义交给 Pi goal/plan；`tomsej/pi-ext` Ask User Question 等扩展 UI 能 round-trip 再考虑。不要再写第二套 `load_skill` / `search_tools` 包装器。
+
+## 本切片已收（步骤 1–2）
+
+`feat/pi-progressive-disclosure` 只做提示与 Skill 名录，不改 MCP / Skills **配置**（路径、Settings 开关、`disabledSkills` 加载器、`internal/agentresources`、`setActiveTools` 政策）：
+
+1. **删双重披露**：`before_agent_start` 不再复述 ask / progress / workspace 动作表 / `tool_result` 截断 MUST。when-to-use 只留在对应 tool description。宿主 OS/cwd、角色、以及浏览器/子 Agent 已打开时的短说明仍注入。
+2. **Skill 按 Pi 标准收描述**：first-party `description` 改成 routing rule；`release-milksu` 设 `disable-model-invocation: true`。正文继续靠 `read` 或 `/skill:`。不改 `bridge-skills.js` 的路径解析。
+
+## 未做（留给 MCP/Skills 配置重构或其他切片）
+
+3. **可选胖工具学隔离浏览器**：继续在 extension 里 `registerTool`，初始 `activeTools` 只留 Pi 文件/Shell + 最多 3 个产品 UI 工具；LSP / ImageGen / CUA 准备器跟浏览器一样，由类型化动作激活。  
+4. **只有目录真的涨到几十上百**（大量项目 MCP）才接 Pi 自带的 `search_tools` + `setActiveTools` 加法激活。现在大约十个可选工具，不够资格自造搜索层。  
+5. **不要**扫描用户句子来决定加载；**不要**为“怕不触发”把 Skill 正文或 workspace 动作表贴回 system prompt。
+
+## 来源
+
+- https://agentskills.io/integrate-skills  
+- https://agentskills.io/specification  
+- `node_modules/@earendil-works/pi-coding-agent/docs/skills.md`  
+- `node_modules/@earendil-works/pi-coding-agent/docs/extensions.md`（Dynamic Tool Loading）  
+- https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool  
+- https://modelcontextprotocol.io/docs/2026-07-28/develop/clients/client-best-practices  
+- https://docs.openhands.dev/overview/skills（Skill 三层披露可对齐；其 keyword `triggers` 不采用）

--- a/sidecar/pi/bridge-skills.test.js
+++ b/sidecar/pi/bridge-skills.test.js
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { formatSkillsForPrompt } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -57,4 +59,40 @@ test("CTF roles can load the same reviewed Coding skills", () => {
     reviewedCodingSkillPaths(repositoryRoot, "solver", []),
     reviewedCodingSkillPaths(repositoryRoot, "", []),
   );
+});
+
+function skillFrontmatter(name) {
+  const text = readFileSync(join(repositoryRoot, "skills", name, "SKILL.md"), "utf8");
+  const match = text.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(match, `${name} has YAML frontmatter`);
+  const fields = {};
+  for (const line of match[1].split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) continue;
+    fields[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  return fields;
+}
+
+test("first-party skill descriptions are Pi routing rules", () => {
+  const catalog = [];
+  for (const name of firstPartyCodingSkillNames) {
+    const fields = skillFrontmatter(name);
+    assert.equal(fields.name, name);
+    assert.match(fields.description, /Use /);
+    assert.ok(
+      fields.description.length <= 400,
+      `${name} description stays near the 50-100 token routing budget`,
+    );
+    catalog.push({
+      name,
+      description: fields.description,
+      filePath: join(repositoryRoot, "skills", name, "SKILL.md"),
+      disableModelInvocation: fields["disable-model-invocation"] === "true",
+    });
+  }
+  assert.equal(skillFrontmatter("release-milksu")["disable-model-invocation"], "true");
+  const prompt = formatSkillsForPrompt(catalog);
+  assert.match(prompt, /frontend-visual-qa/);
+  assert.doesNotMatch(prompt, /release-milksu/);
 });

--- a/sidecar/pi/bridge-workflow-prompt.js
+++ b/sidecar/pi/bridge-workflow-prompt.js
@@ -1,0 +1,55 @@
+import { codingBrowserGuidance } from "./bridge-browser-policy.js";
+import {
+  codingSubagentGuidance,
+  codingWorkspaceIdentityGuidance,
+} from "./bridge-collaboration.js";
+import { runtimeEnvironmentGuidance } from "./bridge-runtime-environment.js";
+import { researchReportGuidance } from "./bridge-workspace.js";
+
+export function roleGuidanceForSession(sessionRole) {
+  if (sessionRole === "strategist") {
+    return "Act as an independent reviewer: challenge the current route and return an evidence-backed recommendation.";
+  }
+  if (sessionRole === "tool-builder") {
+    return "Treat the requested helper as a software deliverable and verify it.";
+  }
+  if (sessionRole === "solver") {
+    return "Advance one falsifiable CTF hypothesis at a time and preserve evidence for the learner.";
+  }
+  if (sessionRole === "cve-research" || sessionRole === "lab-job") {
+    return researchReportGuidance(sessionRole);
+  }
+  return "";
+}
+
+// Product tools keep their when-to-use in the tool description / Skill catalog.
+// This suffix only adds host facts Pi does not own: role, OS/cwd, and
+// surfaces that are actually on for this session.
+export function composeMilkSUWorkflowSystemPrompt(systemPrompt, {
+  sessionRole = "",
+  policy = {},
+  modelInput,
+} = {}) {
+  const roleGuidance = roleGuidanceForSession(sessionRole);
+  const workspaceIdentityGuidance = codingWorkspaceIdentityGuidance(
+    policy?.workspace,
+    policy?.codingCollaboration,
+  );
+  const subagentGuidance = policy?.activeTools?.includes("subagent")
+    ? `\n\n${codingSubagentGuidance()}`
+    : "";
+  const browserGuidance = policy?.codingBrowser
+    ? `\n\n${codingBrowserGuidance()}`
+    : "";
+  return `${systemPrompt ?? ""}`
+    + (roleGuidance ? `\n\n${roleGuidance}` : "")
+    + `\n\nRuntime context:\n${runtimeEnvironmentGuidance({
+      uiLocale: policy?.uiLocale,
+      modelInput,
+    })}`
+    + (workspaceIdentityGuidance
+      ? `\n\nWorkspace identity:\n${workspaceIdentityGuidance}`
+      : "")
+    + subagentGuidance
+    + browserGuidance;
+}

--- a/sidecar/pi/bridge-workflow-prompt.test.js
+++ b/sidecar/pi/bridge-workflow-prompt.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  composeMilkSUWorkflowSystemPrompt,
+  roleGuidanceForSession,
+} from "./bridge-workflow-prompt.js";
+
+test("workflow prompt keeps host facts and omits product-tool essays", () => {
+  const prompt = composeMilkSUWorkflowSystemPrompt("You are MilkSU.", {
+    sessionRole: "solver",
+    policy: {
+      workspace: "/workspace",
+      uiLocale: "zh-CN",
+      codingBrowser: true,
+      activeTools: ["subagent", "milksu_workspace", "milksu_ask", "milksu_progress"],
+    },
+  });
+  assert.match(prompt, /You are MilkSU/);
+  assert.match(prompt, /Runtime context/);
+  assert.match(prompt, /Workspace identity/);
+  assert.match(prompt, /falsifiable CTF hypothesis/);
+  assert.match(prompt, /When the user asks to open a subagent/);
+  assert.match(prompt, /built-in isolated browser/);
+  assert.doesNotMatch(prompt, /milksu_progress/);
+  assert.doesNotMatch(prompt, /milksu_ask/);
+  assert.doesNotMatch(prompt, /MUST call/);
+  assert.doesNotMatch(prompt, /50KB or 2000 lines/);
+  assert.doesNotMatch(prompt, /list_records/);
+  assert.doesNotMatch(prompt, /Do not scan the user message/);
+});
+
+test("workflow prompt skips optional surfaces that are off", () => {
+  const prompt = composeMilkSUWorkflowSystemPrompt("base", {
+    sessionRole: "",
+    policy: { activeTools: [] },
+  });
+  assert.equal(roleGuidanceForSession(""), "");
+  assert.match(prompt, /^base\n\nRuntime context:/);
+  assert.doesNotMatch(prompt, /subagent/);
+  assert.doesNotMatch(prompt, /isolated browser/);
+});

--- a/sidecar/pi/bridge-workspace.js
+++ b/sidecar/pi/bridge-workspace.js
@@ -80,18 +80,8 @@ export function researchReportGuidance(sessionRole = "") {
 
 export function codingWorkspaceGuidance() {
   return [
-    "Use milksu_workspace to operate MilkSU the way the user would.",
-    "Product records are atomic: list_records, get_record, create_record, update_record, archive_records, restore_records, focus_record, and search_records, with kind conversation | lab | cve | ctf.",
-    "Compose those atoms instead of asking for a dedicated feature: rename with update_record, batch archive with archive_records ids, import a CVE with search_records then create_record, or open a page with open_browser_tab and later create_record for a custom CTF.",
-    "List browser tabs, then focus one by tabId (or a unique title/url query) before milksu-playwright clicks.",
-    "Close one tab or close_all_browser_tabs when the user wants the right-hand pages gone.",
-    "List or preview workspace artifacts and show_panel to open 产物 / 浏览器 / 变更 / 环境.",
-    "Use list_status for Git, model, permission, and context facts the environment panel shows.",
-    "Context compaction is automatic at about 85% of the model window, using the same Pi compact path as /compact.",
-    "compact_context always queues that Pi compact path, even below 85%; 85% is only the automatic idle trigger.",
-    "Use show_terminal / list_terminals / list_background_tasks for the bottom terminal and Agent background jobs.",
-    "Do not scan the user message for keywords; choose these typed actions from the request.",
-    "Do not change Settings, credentials, approval policy, Computer Use scope, or the user's real Chrome.",
+    "Use milksu_workspace when the user wants MilkSU records, isolated browser tabs, artifacts, environment status, or the bottom terminal.",
+    "Pick a typed action from the tool schema; do not scan the user message.",
   ].join(" ");
 }
 
@@ -223,7 +213,7 @@ export function createCodingWorkspaceExtension(
     pi.registerTool({
       name: codingWorkspaceToolName,
       label: "MilkSU workspace",
-      description: "Operate MilkSU product data and the desktop: conversations, lab jobs, CVE and CTF records, isolated browser tabs, artifacts, environment/status, changes, context compaction, and the bottom terminal. Use atomic typed actions (list/get/create/update/archive/focus/search with a kind) instead of asking the user to click the UI, then use milksu-playwright on the focused tab.",
+      description: codingWorkspaceGuidance(),
       parameters: Type.Object({
         action: Type.Union([
           Type.Literal("list_browser_tabs"),

--- a/sidecar/pi/bridge-workspace.test.js
+++ b/sidecar/pi/bridge-workspace.test.js
@@ -84,14 +84,13 @@ test("research report guidance tells the model to edit report.md", () => {
   assert.match(researchReportGuidance("cve-research"), /上游/);
 });
 
-test("workspace guidance tells the model to use typed UI actions", () => {
-  assert.match(codingWorkspaceGuidance(), /milksu_workspace/);
-  assert.match(codingWorkspaceGuidance(), /tabId/);
-  assert.match(codingWorkspaceGuidance(), /Do not scan the user message/);
-  assert.match(codingWorkspaceGuidance(), /85%/);
-  assert.match(codingWorkspaceGuidance(), /list_status/);
-  assert.match(codingWorkspaceGuidance(), /list_records/);
-  assert.match(codingWorkspaceGuidance(), /kind conversation/);
+test("workspace guidance is a short when-to-use routing rule", () => {
+  const text = codingWorkspaceGuidance();
+  assert.match(text, /milksu_workspace/);
+  assert.match(text, /do not scan the user message/);
+  assert.doesNotMatch(text, /list_records/);
+  assert.doesNotMatch(text, /85%/);
+  assert.ok(text.length < 280);
   assert.equal(
     formatCodingWorkspaceInput({
       action: "focus_browser_tab",
@@ -160,6 +159,7 @@ test("workspace extension registers one reviewed desktop tool", async () => {
     },
   });
   assert.equal(tools[0]?.name, "milksu_workspace");
+  assert.equal(tools[0]?.description, codingWorkspaceGuidance());
   const result = await tools[0].execute("call-1", { action: "list_browser_tabs" });
   assert.equal(requested[0].action, "list_browser_tabs");
   assert.match(result.content[0].text, /tabs/);

--- a/sidecar/pi/bridge.js
+++ b/sidecar/pi/bridge.js
@@ -109,16 +109,12 @@ import {
   formatSubagentApproval,
   normalizeCodingCollaboration,
   validateSubagentInput,
-  codingSubagentGuidance,
-  codingWorkspaceIdentityGuidance,
 } from "./bridge-collaboration.js";
 import {
   authorizeImageGenToolCall,
   codingImageGenToolName,
 } from "./bridge-imagegen.js";
 import {
-  codingWorkspaceGuidance,
-  researchReportGuidance,
   resolveWorkflowSessionRole,
   codingWorkspaceToolName,
   createCodingWorkspaceExtension,
@@ -126,6 +122,7 @@ import {
   formatCodingWorkspaceInput,
   queueWorkspaceCompaction,
 } from "./bridge-workspace.js";
+import { composeMilkSUWorkflowSystemPrompt } from "./bridge-workflow-prompt.js";
 import { createEnvExtension } from "./bridge-env.js";
 import { createComputerUseDriverExtension } from "./bridge-computer-use-driver.js";
 import { reviewedCodingSkillPaths } from "./bridge-skills.js";
@@ -142,7 +139,6 @@ import {
   removeQueuedMessage,
   steerSession,
 } from "./bridge-steering.js";
-import { runtimeEnvironmentGuidance } from "./bridge-runtime-environment.js";
 import {
   destructiveDeleteDecision,
 } from "./bridge-destructive-delete.js";
@@ -375,7 +371,7 @@ function createMilkSUWorkflowExtension(sessionRole, getPolicy, getSession, conve
     pi.registerTool({
       name: codingAskToolName,
       label: "MilkSU ask",
-      description: "Show an interactive choice card so the user can tap one of 2-6 options. Required whenever you ask the user a multiple-choice question, including when they ask you to present options. Wait for the selected option. Do not write the options as a numbered or bulleted list.",
+      description: "Show a tappable choice card with 2-6 options. Use when asking a multiple-choice question or when the user asks you to present options. Wait for the selected option; do not write the choices as a numbered or bulleted list.",
       parameters: Type.Object({
         question: Type.String({ minLength: 1, maxLength: 200 }),
         options: Type.Array(Type.Object({
@@ -411,7 +407,7 @@ function createMilkSUWorkflowExtension(sessionRole, getPolicy, getSession, conve
     pi.registerTool({
       name: "milksu_progress",
       label: "MilkSU progress",
-      description: "Publish or update a short execution plan (summary + up to 8 steps) so the desktop can show Codex-style progress. Call this when the task has multiple steps, and update statuses as you advance.",
+      description: "Publish or update a short execution plan (summary + up to 8 steps) when the task has more than one concrete step. Skip one-shot replies. Keep the in-progress step updated.",
       parameters: Type.Object({
         summary: Type.String({ minLength: 1, maxLength: 240 }),
         steps: Type.Array(Type.Object({
@@ -445,45 +441,13 @@ function createMilkSUWorkflowExtension(sessionRole, getPolicy, getSession, conve
     });
 
     pi.on("before_agent_start", async (event) => {
-      const roleGuidance = sessionRole === "strategist"
-        ? "Act as an independent reviewer: challenge the current route and return an evidence-backed recommendation."
-        : sessionRole === "tool-builder"
-          ? "Treat the requested helper as a software deliverable and verify it."
-          : sessionRole === "solver"
-            ? "Advance one falsifiable CTF hypothesis at a time and preserve evidence for the learner."
-            : sessionRole === "cve-research" || sessionRole === "lab-job"
-              ? researchReportGuidance(sessionRole)
-              : "";
       const policy = getPolicy?.();
-      const workspaceIdentityGuidance = codingWorkspaceIdentityGuidance(
-        policy?.workspace,
-        policy?.codingCollaboration,
-      );
-      const subagentGuidance = policy?.activeTools?.includes("subagent")
-        ? `\n\n${codingSubagentGuidance()}`
-        : "";
-      const browserGuidance = policy?.codingBrowser
-        ? `\n\n${codingBrowserGuidance()}`
-        : "";
-      const workspaceGuidance = policy?.activeTools?.includes(codingWorkspaceToolName)
-        ? `\n\n${codingWorkspaceGuidance()}`
-        : "";
       return {
-        systemPrompt: `${event.systemPrompt}`
-          + (roleGuidance ? `\n\n${roleGuidance}` : "")
-          + `\n\nRuntime context:\n${runtimeEnvironmentGuidance({
-            uiLocale: policy?.uiLocale,
-            modelInput: getSession?.()?.model?.input,
-          })}`
-          + (workspaceIdentityGuidance
-            ? `\n\nWorkspace identity:\n${workspaceIdentityGuidance}`
-            : "")
-          + subagentGuidance
-          + browserGuidance
-          + workspaceGuidance
-          + "\n\nWhen a task needs more than one concrete step, publish a concise plan with milksu_progress and keep the in-progress step updated. Skip the tool for trivial one-shot replies."
-          + "\n\nIf you are asking the user a multiple-choice question, or the user asks you to present options they can pick, you MUST call milksu_ask immediately with a short question and 2-6 options, then wait. Never write the choices as a numbered or bulleted list in the assistant message. milksu_ask is the interactive choice card; it is not a tool-permission prompt."
-          + "\n\nTool results in model context follow Pi truncation (50KB or 2000 lines). Overflow is saved to a file named in the truncation notice; continue with the read tool and offset. Do not pull full command, HTTP, or file dumps into context.",
+        systemPrompt: composeMilkSUWorkflowSystemPrompt(event.systemPrompt, {
+          sessionRole,
+          policy,
+          modelInput: getSession?.()?.model?.input,
+        }),
       };
     });
   };

--- a/skills/create-technical-deliverables/SKILL.md
+++ b/skills/create-technical-deliverables/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-technical-deliverables
-description: Create or update a human-readable technical deliverable such as a README, runbook, implementation note, CTF write-up, CVE research report, reproduction guide, script package, or evidence summary. Use when the user needs a durable document or reproducible handoff rather than only a chat answer. Do not use for internal progress logs with no reader.
+description: Write a readable, reproducible report, runbook, write-up, or script note. Use when the user needs a durable document rather than only a chat answer.
 ---
 
 # Create Technical Deliverables

--- a/skills/frontend-visual-qa/SKILL.md
+++ b/skills/frontend-visual-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-visual-qa
-description: Implement, debug, redesign, or review Web frontend changes with evidence from the project test runner, a real preview server, and MilkSU's isolated Coding Browser. Use for HTML, CSS, Vue, React, responsive layout, accessibility, interaction, Console or Network failures, screenshot comparison, and visual regression tasks. Do not use for native-app-only validation that requires Computer Use instead of a browser.
+description: Review or fix web UI with a live preview and MilkSU's isolated Coding Browser. Use for HTML, CSS, Vue/React layout, accessibility, console/network failures, or visual regression. Do not use for native-app Computer Use.
 ---
 
 # Frontend Visual QA

--- a/skills/integrate-api/SKILL.md
+++ b/skills/integrate-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-api
-description: Integrate an external API, SDK, OAuth provider, webhook, hosted model, or service using current official documentation and a verified end-to-end request. Use for third-party authentication, cloud services, model providers, billing or quota APIs, data synchronization, and webhook flows. Do not use for purely local code with no external contract.
+description: Connect an external API, SDK, OAuth, webhook, or hosted model using current official docs and a verified request. Use for third-party auth, cloud, billing, or sync. Do not use for purely local code.
 ---
 
 # Integrate API

--- a/skills/product-design/SKILL.md
+++ b/skills/product-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-design
-description: Design, redesign, or materially change a product interface or user flow before implementation, then verify the rendered result. Use for new pages, major components, navigation or workflow changes, screenshot-based implementation, visual modernization, and UX audits. Do not use for tiny copy, spacing, color, or obvious defect fixes that preserve the existing design.
+description: Set the visual goal for a major UI or flow change, then implement and verify the rendered result. Use for new pages, navigation, or redesigns. Do not use for tiny copy, spacing, or color fixes.
 ---
 
 # Product Design

--- a/skills/release-milksu/SKILL.md
+++ b/skills/release-milksu/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release-milksu
-description: Build, verify, publish, or audit a traced MilkSU Stable desktop release for macOS ARM64 and Windows x64. Use only inside the MilkSU repository when the user asks to package, release, publish, promote, or inspect a MilkSU desktop version. Build MilkSU Beta only for an explicitly requested Stable-to-Beta self-bootstrap exercise.
+description: Build, verify, or publish a MilkSU desktop release. Use only when the user asks to package, release, or inspect a MilkSU version.
+disable-model-invocation: true
 ---
 
 # Release MilkSU

--- a/skills/review-security/SKILL.md
+++ b/skills/review-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-security
-description: Review a repository, change set, authentication flow, integration, or product boundary for concrete security risks involving credentials, authorization, untrusted input, filesystem or network scope, external effects, and vulnerable data flows. Use for security reviews, pre-release checks, auth and quota changes, and suspicious code. Do not use to conduct attacks against external targets.
+description: Review credentials, authorization, input boundaries, filesystem or network scope, and external side effects. Use for security reviews, auth or quota changes, and suspicious code. Do not use to attack external targets.
 ---
 
 # Review Security


### PR DESCRIPTION
## Summary

- 按 Pi 0.84.1 / Agent Skills 的渐进披露收束 MilkSU 附加层：`before_agent_start` 不再把 `milksu_ask` / `milksu_progress` / workspace 动作表 / `tool_result` 截断说明再写一遍 MUST。when-to-use 只留在对应 tool description。
- First-party Skill 名录 `description` 改成短 routing rule；`release-milksu` 设 Pi 原生 `disable-model-invocation: true`（模型名录隐藏，`/skill:release-milksu` 仍可用）。Settings 里的 Skills 开关与 UI 文案未改。
- 宿主 OS/cwd、会话角色、以及浏览器/子 Agent **已经打开**时的短说明仍注入。没有关键词路由，也没有自造 on-demand injector。

依据：消融见 `docs/developer/research-harness-ablation.md`（附加层约 3600 token，解题率没掉，贵在双重披露）；标准对照见 `docs/developer/research-progressive-disclosure.md`。

产品准入：复用 Pi Skill 名录与已有 tool description，不建第二套 harness，不扫用户句子。

## 与正在进行的 MCP / Skills 配置重构互不踩踏

本 PR **只动提示与 Skill 前言**，从干净的 `main`（`5fd4bb8`）拉出，**没有**带上 `feat/loop-context-operators` 或本地 dirty 的配置重构文件。

本 PR **没有改**（请配置重构继续独占）：

- `sidecar/pi/bridge-skills.js` 路径解析 / `disabledSkills`
- `sidecar/pi/bridge-mcp.js`、`internal/codingenv/mcp.go`、MCP adapter
- `codingWorkspaceAutoToolNames` / `setActiveTools` 政策
- Settings Skills/MCP UI、`app/src/codingSkills.ts`
- `internal/agentresources/`、`cmd/milksu-backend/app_agent_resources.go`、`app.go`

本 PR **改了**：

- `sidecar/pi/bridge.js` 的 workflow `before_agent_start` 与 ask/progress description
- 新文件 `sidecar/pi/bridge-workflow-prompt.js`（可测的 prompt 组装）
- `sidecar/pi/bridge-workspace.js` 的短 when-to-use（同时作为 tool description）
- `skills/*/SKILL.md` **只改 YAML frontmatter**（`description` / `disable-model-invocation`），不改正文流程
- 研究文档与 `current-objectives.md` 未发版记录

未做（留给配置重构或其他切片）：按隔离浏览器的方式收窄初始 `activeTools`、上 Pi `search_tools`。若配置重构也要改 `skills/*/SKILL.md` 正文或 frontmatter，请先合本 PR 或避开 `description` / `disable-model-invocation` 这两行。

## Test plan

- [x] `node --test sidecar/pi/bridge-workflow-prompt.test.js sidecar/pi/bridge-workspace.test.js sidecar/pi/bridge-skills.test.js`
- [x] 更广的 sidecar 集（workspace / skills / workflow / browser / collaboration / context-composition / policy / loop-integration）89 通过
- [ ] 真实会话：多步任务仍可通过 tool description 调用 `milksu_progress`；选择题仍走 `milksu_ask`，不再依赖 system prompt MUST
- [ ] `/skill:release-milksu` 仍可用；普通 Coding 任务的 `<available_skills>` 不再出现 `release-milksu`
- [ ] 配置重构分支 rebase 时确认没有同时改 `bridge-skills.js` / MCP loader


Made with [Cursor](https://cursor.com)