### PR TITLE
Stop parent-loop bg_status polling and allow four read-only subagent lanes

### DIFF
--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -32,7 +32,7 @@
 | 历史基线 | M3 product-loop 已在 `108e0e3`（2026-08-05）合并，仅供追溯。 |
 | 正式发行基线 | `v26.905.2 / b18b8607e2645c3977125e79d0257256951ae6b5`（2026-09-05 今日第二版）。这是当前 GitHub Latest Release；提供带版本号的 DMG、EXE、DEB、x64 tar.gz 与 `SHA256SUMS`。OTA 已上传私有 R2。侧栏下载先 `checkForUpdates` 再 `downloadUpdate`。已发出的 `26.827.1` / `26.904.1` / `26.905.1` 客户端改不了，这一跳请从 GitHub 下安装包。上一版 `v26.905.1 / 1cc8773`、`v26.904.1 / 6e9371d` 与 `v26.827.1 / 37932ce` 仍可下载，不是 Latest。 |
 | 开发版本线 | 根目录与 `desktop/package.json` 是 `26.905.2`。正式发行源是 `b18b860`；文档收口提交不移动该 tag。 |
-| 当前开发 | 正式包是 `26.905.2`。Composer 上下文环按 Pi 组装分类；设置页可查看并覆盖模型上下文窗口。edit 锚点、`tool_result` 截断、中途引导、子 Agent 结构化回传、rewind/handoff、用户 MCP/Skills 与克制清透材料层已进包。侧栏下载先 check 再 download，失败可见重试。三端窗口铬：macOS 保持 `hiddenInset`，Windows/Linux 隐藏原生标题栏并用画布色 overlay。已登录 Stable 轮询 Admin 时带上当前版本。实验室题目包仍可起本机 Docker / MilkSU-Lab。Pi 钉到 `0.84.1`。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；Hyprland/Xorg Computer Use 不可用。CTF 比赛模式和实验室红队学习面仍未接线。产品 UI 设计语言只写在 `AGENTS.md`。 |
+| 当前开发 | 正式包是 `26.905.2`。Composer 上下文环按 Pi 组装分类；设置页可查看并覆盖模型上下文窗口。edit 锚点、`tool_result` 截断、中途引导、子 Agent 结构化回传、rewind/handoff、用户 MCP/Skills 与克制清透材料层已进包。侧栏下载先 check 再 download，失败可见重试。三端窗口铬：macOS 保持 `hiddenInset`，Windows/Linux 隐藏原生标题栏并用画布色 overlay。已登录 Stable 轮询 Admin 时带上当前版本。实验室题目包仍可起本机 Docker / MilkSU-Lab。Pi 钉到 `0.84.1`。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；Hyprland/Xorg Computer Use 不可用。CTF 比赛模式和实验室红队学习面仍未接线。产品 UI 设计语言只写在 `AGENTS.md`。未发版：`fix/wide-job-parent-loop` 给 parent loop 加上 `bg_status` poller 熔断，并把 `subagent` 从「用户开口才调用」改回最多 4 条 read-only lane；#53 的 typed sweep 工具尚未做。 |
 | 平台边界 | `26.905.2`：macOS DMG 走 GitHub-hosted Developer ID 签名并公证；Windows 安装器完成原生 Runtime 与首次启动但未代码签名，并打入审阅过的 CUA Driver；Linux 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball，GNOME Portal Computer Use 已进包，仍无 Secret Service、本地 OCR；Hyprland/Xorg Computer Use 不可用。Windows/Linux 窗口铬尚未真机验收。 |
 | 发行流水 | 下一发行从干净、已推送的 `main` 对 canonical Go/Vue/Sidecar/lint/生产与文档构建只验证一次；macOS / Windows / Linux 都走 GitHub-hosted 云端。macOS 本机打包暂时关闭。必须创建 GitHub Release 页并上传带版本号的 DMG/EXE/DEB、x64 tar.gz 与 SHA256SUMS，不能只留空 tag。正式打包默认上传 OTA 到私有 R2 并建 Admin 草稿；GitHub Release 仍不上 updater ZIP。 |
 
@@ -245,6 +245,7 @@ Windows 签名、Linux Secret Service / OCR、Hyprland/Xorg Computer Use、Windo
 | P0 | Pi Runtime 用户验收 | 最新正式包中验证跨目录读写、CTF/CVE 交接、长输出续跑和重启恢复，不出现 MilkSU 自建 workspace 策略或旧 session ID。 |
 | P1 | 下一版三端回执发行 | 需要新的版本号、同一 source commit、三端产物、SHA-256 与平台验收。现有 `v26.905.2` 只覆盖 `b18b860`。 |
 | P1 | Admin current pointer / 客户端下载 | `26.905.2` 已先 `checkForUpdates` 再 `downloadUpdate`。从更早正式包到本版请下 GitHub 安装包。Admin current pointer 仍须维护者发布后，后续 hop 才能走 OTA。 |
+| P1 | Wide lab parent loop（#53） | `bg_status` poller 熔断与最多 4 条 read-only `subagent` lane 在 `fix/wide-job-parent-loop`。未发版、未经验收。typed sweep / inventory 工具只在真实 wide job 仍用 bash 复刻库存后再做。 |
 | P1 | 安全工具真实任务 | IDA/idalib 与 capa 已有设置、准备和健康检查；用受控本地样本留下真实任务回执。就绪工具接到实验室作业，窄工具也可进 CVE 复现；不需要先开一次“是否投影”的会。不把 HexStrike 整包 MCP 做成产品页或 Kali 应用商店。CodeQL、Burp、Shannon 仍逐项接入。 |
 | P1 | Obelisk 学习记录 | 先定义可归因学习事实，再设计独立页面；不恢复已删除的单会话相关历史/图谱面板。 |
 | 未接线 | 继续同一作业还是新开一轮 | 当前按同一 CVE/实验室作业复用同一会话和 `report.md`。新开一轮的产品决策还没定。 |

--- a/sidecar/pi/bridge-collaboration.js
+++ b/sidecar/pi/bridge-collaboration.js
@@ -18,7 +18,8 @@ const worktreeAgents = new Set([
   "worker",
 ]);
 const allAgents = new Set([...readOnlyAgents, ...worktreeAgents]);
-const maxTasksPerCall = 2;
+const maxWriterWorktrees = 2;
+const maxTasksPerCall = 4;
 const maxTaskCharacters = 16000;
 
 function exactObject(value) {
@@ -68,7 +69,7 @@ export function normalizeCodingCollaboration(
     "Coding collaboration root",
   );
   const worktrees = Array.isArray(value.worktrees) ? value.worktrees : [];
-  if (worktrees.length < 1 || worktrees.length > maxTasksPerCall) {
+  if (worktrees.length < 1 || worktrees.length > maxWriterWorktrees) {
     throw new Error("Coding collaboration requires one or two writer worktrees");
   }
   const key = taskKey(normalizedConversation);
@@ -157,8 +158,8 @@ export function isReadOnlySubagent(agent) {
 
 export function codingSubagentGuidance() {
   return [
-    "When the user asks to open a subagent or delegate a lookup, call the subagent tool.",
-    "Read-only roles: scout, planner, reviewer, security-auditor.",
+    "Read-only roles: scout, planner, reviewer, security-auditor. Those work without a writer worktree.",
+    "MilkSU allows at most four subagent tasks per approved call. Effectful roles still need prepared writer worktrees.",
     "Do not treat the words subagent, sub-agent, or subapi as IDA Pro, idalib, or a security MCP.",
     "IDA is only for a local binary the user named.",
   ].join(" ");

--- a/sidecar/pi/bridge-collaboration.test.js
+++ b/sidecar/pi/bridge-collaboration.test.js
@@ -177,6 +177,35 @@ test("read-only subagents work without collaboration worktrees", async () => {
   assert.match(summary, /scout → 主工作树（只读角色）/);
   assert.match(codingSubagentGuidance(), /subapi/);
   assert.match(codingSubagentGuidance(), /IDA Pro/);
+  assert.match(codingSubagentGuidance(), /at most four/);
+  assert.doesNotMatch(codingSubagentGuidance(), /When the user asks to open a subagent/);
+});
+
+test("read-only parallel lanes accept four scouts and reject a fifth", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "milksu-subagent-lanes-"));
+  const accepted = validateSubagentInput({
+    tasks: [
+      { agent: "scout", task: "HTTP surface" },
+      { agent: "scout", task: "DNS and certificates" },
+      { agent: "security-auditor", task: "bound lease extras" },
+      { agent: "reviewer", task: "summarize inventory gaps" },
+    ],
+  }, undefined, workspace);
+  assert.equal(accepted.mode, "parallel");
+  assert.equal(accepted.tasks.length, 4);
+  assert.equal(accepted.tasks.every(task => task.access === "read-only"), true);
+  assert.throws(
+    () => validateSubagentInput({
+      tasks: [
+        { agent: "scout", task: "one" },
+        { agent: "scout", task: "two" },
+        { agent: "scout", task: "three" },
+        { agent: "scout", task: "four" },
+        { agent: "scout", task: "five" },
+      ],
+    }, undefined, workspace),
+    /at most 4 subagent tasks/,
+  );
 });
 
 test("approval summary exposes role, mode, branch, and task", async () => {

--- a/sidecar/pi/bridge-tool-repeat.js
+++ b/sidecar/pi/bridge-tool-repeat.js
@@ -4,14 +4,22 @@
 // return `{ block: true, terminate: true }` from `tool_call`, or wait on the
 // existing approval broker before allowing the call through. This module only
 // inspects the current user prompt's tool sequence; it does not replace Pi's loop.
+//
+// pi-better-background-tasks already returns immediately from spawn/watch and
+// queues a terminal callback. Parent-loop bg_status polling is the no-progress
+// case; do not add a second wait/poll primitive on top of that callback.
 
 export const exactRepeatLimit = 10;
 export const familyRepeatLimit = 25;
+export const statusPollLimit = 12;
+export const statusPollBudgetLimit = 8;
 export const promptToolLimit = 150;
 export const toolBudgetToolName = "milksu_tool_budget";
+export const statusPollFamily = "bg_status\0poll";
 
 export const exactRepeatReason = "同一命令连续重复，已停止本轮。";
 export const familyRepeatReason = "相近命令没有新进展，已停止本轮。";
+export const statusPollReason = "后台任务状态没有新进展，已停止本轮。";
 export const promptToolLimitReason = "本轮已停止。";
 
 function stableValue(value) {
@@ -43,15 +51,28 @@ export function bashFamilyCommand(command) {
   return text.replace(/\s+/g, " ").trim();
 }
 
+function backgroundStatusId(input) {
+  return String(input?.id ?? "").trim();
+}
+
+function backgroundStatusAction(input) {
+  return String(input?.action ?? "status").trim().toLowerCase();
+}
+
 export function toolCallSignature(toolName, input) {
   const name = String(toolName ?? "").trim().toLowerCase();
   if (name === "bash") return `bash\0${bashCommand(input)}`;
+  if (name === "bg_status") {
+    const id = backgroundStatusId(input);
+    return id ? `bg_status\0${id}` : `bg_status\0${backgroundStatusAction(input)}`;
+  }
   return `${name}\0${stableValue(input)}`;
 }
 
 export function toolCallFamily(toolName, input) {
   const name = String(toolName ?? "").trim().toLowerCase();
   if (name === "bash") return `bash\0${bashFamilyCommand(bashCommand(input))}`;
+  if (name === "bg_status") return statusPollFamily;
   return toolCallSignature(name, input);
 }
 
@@ -78,10 +99,16 @@ export function inspectToolRepeat(history, toolName, input) {
   if (exactCount >= exactRepeatLimit) {
     return { block: true, terminate: true, reason: exactRepeatReason };
   }
+  if (family === statusPollFamily && familyCount >= statusPollLimit) {
+    return { block: true, terminate: true, reason: statusPollReason };
+  }
   if (familyCount >= familyRepeatLimit) {
     return { block: true, terminate: true, reason: familyRepeatReason };
   }
   if (promptCount > 0 && promptCount % promptToolLimit === 0) {
+    if (family === statusPollFamily && familyCount >= statusPollBudgetLimit) {
+      return { block: true, terminate: true, reason: statusPollReason };
+    }
     return { ask: true, count: promptCount };
   }
   return undefined;

--- a/sidecar/pi/bridge-tool-repeat.test.js
+++ b/sidecar/pi/bridge-tool-repeat.test.js
@@ -9,6 +9,10 @@ import {
   familyRepeatReason,
   inspectToolRepeat,
   promptToolLimit,
+  statusPollBudgetLimit,
+  statusPollFamily,
+  statusPollLimit,
+  statusPollReason,
   toolBudgetPrompt,
   toolCallFamily,
   toolCallSignature,
@@ -86,4 +90,66 @@ test("resets between user prompts", () => {
   for (let index = 0; index < 4; index += 1) guard.inspect("bash", call);
   guard.reset();
   assert.equal(guard.inspect("bash", call), undefined);
+});
+
+test("treats bg_status status and log on the same id as one exact family", () => {
+  assert.equal(
+    toolCallSignature("bg_status", { action: "status", id: "bg_one" }),
+    toolCallSignature("bg_status", { action: "log", id: "bg_one" }),
+  );
+  assert.notEqual(
+    toolCallSignature("bg_status", { action: "status", id: "bg_one" }),
+    toolCallSignature("bg_status", { action: "status", id: "bg_two" }),
+  );
+  assert.equal(toolCallFamily("bg_status", { action: "status", id: "bg_one" }), statusPollFamily);
+  assert.equal(toolCallFamily("bg_status", { action: "log", id: "bg_two" }), statusPollFamily);
+});
+
+test("stops a trailing bg_status poller before the generic family limit", () => {
+  const guard = createToolRepeatGuard();
+  for (let index = 0; index < statusPollLimit - 1; index += 1) {
+    assert.equal(guard.inspect("bg_status", { action: "status", id: `bg_${index}` }), undefined);
+  }
+  assert.deepEqual(
+    guard.inspect("bg_status", { action: "log", id: "bg_final" }),
+    { block: true, terminate: true, reason: statusPollReason },
+  );
+});
+
+test("a bg_task spawn resets the bg_status poller streak", () => {
+  const guard = createToolRepeatGuard();
+  for (let index = 0; index < statusPollLimit - 1; index += 1) {
+    assert.equal(guard.inspect("bg_status", { action: "status", id: `bg_${index}` }), undefined);
+  }
+  assert.equal(guard.inspect("bg_task", { action: "spawn", command: "echo ready" }), undefined);
+  assert.equal(guard.inspect("bg_status", { action: "status", id: "bg_after_spawn" }), undefined);
+});
+
+test("stops the same background task id after many status or log calls", () => {
+  const guard = createToolRepeatGuard();
+  for (let index = 0; index < exactRepeatLimit - 1; index += 1) {
+    const action = index % 2 === 0 ? "status" : "log";
+    assert.equal(guard.inspect("bg_status", { action, id: "bg_same" }), undefined);
+  }
+  assert.deepEqual(
+    guard.inspect("bg_status", { action: "status", id: "bg_same" }),
+    { block: true, terminate: true, reason: exactRepeatReason },
+  );
+});
+
+test("tool budget terminates a status poller instead of asking to continue", () => {
+  const history = Array.from({ length: promptToolLimit - statusPollBudgetLimit }, (_, index) => ({
+    signature: `bash\0echo ${index}`,
+    family: `bash\0echo ${index}`,
+  }));
+  for (let index = 0; index < statusPollBudgetLimit - 1; index += 1) {
+    history.push({
+      signature: `bg_status\0bg_${index}`,
+      family: statusPollFamily,
+    });
+  }
+  assert.deepEqual(
+    inspectToolRepeat(history, "bg_status", { action: "status", id: "bg_budget" }),
+    { block: true, terminate: true, reason: statusPollReason },
+  );
 });

--- a/sidecar/pi/bridge-workflow-prompt.test.js
+++ b/sidecar/pi/bridge-workflow-prompt.test.js
@@ -19,7 +19,8 @@ test("workflow prompt keeps host facts and omits product-tool essays", () => {
   assert.match(prompt, /Runtime context/);
   assert.match(prompt, /Workspace identity/);
   assert.match(prompt, /falsifiable CTF hypothesis/);
-  assert.match(prompt, /When the user asks to open a subagent/);
+  assert.match(prompt, /at most four subagent tasks/);
+  assert.doesNotMatch(prompt, /When the user asks to open a subagent/);
   assert.match(prompt, /built-in isolated browser/);
   assert.doesNotMatch(prompt, /milksu_progress/);
   assert.doesNotMatch(prompt, /milksu_ask/);


### PR DESCRIPTION
## Summary
- 本机正式环境 wide lab 作业把上百个探针留在 parent loop 里用 `bg_status` 空转（#53）。这刀只改 Pi 已有的 `tool_call` hook 和 `subagent` 边界，不另起 harness。
- 连续 `bg_status` poller 结束本轮；150 次预算若正停在 poller 则直接停，不再问「要继续吗？」。
- 去掉「用户开口才调用 subagent」；read-only lane 每 call 最多 4 条。typed sweep / inventory 仍未做。

## Test plan
- [x] `node --test sidecar/pi/bridge-tool-repeat.test.js sidecar/pi/bridge-collaboration.test.js sidecar/pi/bridge-workflow-prompt.test.js`
- [ ] 正式包里再跑一条自定义远程 Lab wide job：报告写出后不应再长时间 `bg_status` 空转；模型应能自己选 `subagent`
