### PR TITLE
在 Hyprland 上支持 Computer Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ MilkSU 会把当前任务可用的能力告诉模型，再由模型按上下文�
 | Windows x64 | EXE | ✅ | ✅ |
 | Linux x64 | `.deb` / `.tar.gz` | 见下表 | ✅ |
 
-Linux Computer Use 按桌面，不是按发行版。GNOME 是整桌面授权（不是窗口 Scope）。不接 Cua，不用 `xinput` 摘键鼠。
+Linux Computer Use 按桌面，不是按发行版。GNOME 是整桌面 Portal 授权（不是窗口 Scope）。Hyprland 是另一条整桌面合成器合同，不是 Portal。不接 Cua，不用 `xinput` 摘键鼠。三个 Linux 桌面并不功能等价。
 
 | Linux 桌面 | Computer Use |
-| --- | :---: |
-| GNOME Wayland | ✅ |
-| Hyprland | ❌ |
+| --- | --- |
+| GNOME Wayland | ✅ 整桌面 Portal（已进 `26.905.2`） |
+| Hyprland | 开发线：合成器原生输入；真机验收未做，正式包仍不可用 |
 | Xorg | ❌ |
 
 | Linux 发行版 | 怎么装 |
@@ -148,7 +148,7 @@ Linux 暂无 Secret Service、本地 OCR。合同：[Linux 安装与桌面合同
 
 ## 当前状态
 
-最近一次带哈希回执的三端正式 GitHub Release 是 **26.905.2**（2026-09-05）：侧栏下载先 check 再 download。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；Hyprland/Xorg Computer Use 不可用。
+最近一次带哈希回执的三端正式 GitHub Release 是 **26.905.2**（2026-09-05）：侧栏下载先 check 再 download。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；该正式包里 Hyprland/Xorg Computer Use 不可用。开发 HEAD 已接线 Hyprland 合成器后端，Omarchy 真机验收未做。
 
 MilkSU 面向个人学习、授权研究和本地开发，不是互联网资产扫描器或无人值守的自动红队平台。
 

--- a/app/src/components-vue/CodingComputerUsePanel.test.ts
+++ b/app/src/components-vue/CodingComputerUsePanel.test.ts
@@ -469,6 +469,27 @@ describe('CodingComputerUsePanel', () => {
     expect(text).toContain('合成器原生输入')
     expect(text).toContain('不是 GNOME Portal')
     expect(text).toContain('不是单个窗口')
+    expect(text).toContain('没有这步点击不会创建虚拟指针')
     expect(text).not.toContain('GNOME 会弹出系统桌面共享授权')
+  })
+
+  it('says Hyprland stop returns the seat without leftover injection', async () => {
+    const { host } = await mountPanel({
+      status: status({
+        conversationId: 'current-conversation',
+        enabled: true,
+        signing: {
+          bundleId: 'com.milksu.app',
+          signature: 'linux-hyprland',
+          stableIdentity: true,
+        },
+      }),
+      ownedByCurrentTask: true,
+    })
+    const text = host.textContent ?? ''
+    expect(text).toContain('停止可见会话')
+    expect(text).toContain('销毁 Hyprland 虚拟指针')
+    expect(text).toContain('交还键鼠')
+    expect(text).not.toContain('下一步需要 Agent 对该窗口执行一次可见操作')
   })
 })

--- a/app/src/components-vue/CodingComputerUsePanel.test.ts
+++ b/app/src/components-vue/CodingComputerUsePanel.test.ts
@@ -436,4 +436,39 @@ describe('CodingComputerUsePanel', () => {
     await nextTick()
     expect(onRefresh).toHaveBeenCalledOnce()
   })
+
+  it('describes GNOME Portal as display-level desktop sharing', async () => {
+    const { host } = await mountPanel({
+      status: status({
+        signing: {
+          bundleId: 'com.milksu.app',
+          signature: 'linux-portal',
+          stableIdentity: true,
+        },
+      }),
+    })
+    const text = host.textContent ?? ''
+    expect(text).toContain('当前环境：GNOME 桌面共享')
+    expect(text).toContain('整桌面级输入')
+    expect(text).toContain('不是单个窗口')
+    expect(text).not.toContain('Hyprland 合成器输入')
+  })
+
+  it('describes Hyprland as compositor-native and not Portal', async () => {
+    const { host } = await mountPanel({
+      status: status({
+        signing: {
+          bundleId: 'com.milksu.app',
+          signature: 'linux-hyprland',
+          stableIdentity: true,
+        },
+      }),
+    })
+    const text = host.textContent ?? ''
+    expect(text).toContain('当前环境：Hyprland 合成器输入')
+    expect(text).toContain('合成器原生输入')
+    expect(text).toContain('不是 GNOME Portal')
+    expect(text).toContain('不是单个窗口')
+    expect(text).not.toContain('GNOME 会弹出系统桌面共享授权')
+  })
 })

--- a/app/src/components-vue/CodingComputerUsePanel.vue
+++ b/app/src/components-vue/CodingComputerUsePanel.vue
@@ -91,11 +91,15 @@ const windowsUserSession = computed(() => (
 const linuxPortalSession = computed(() => (
   signingStatus.value?.signature === 'linux-portal'
 ))
+const linuxHyprlandSession = computed(() => (
+  signingStatus.value?.signature === 'linux-hyprland'
+))
 const signingIdentityLabel = computed(() => {
   const signing = signingStatus.value
   if (!signing) return t('当前构建身份：未检测', 'Current build identity: not detected')
   if (windowsUserSession.value) return t('当前环境：Windows 普通用户会话', 'Current environment: Windows user session')
   if (linuxPortalSession.value) return t('当前环境：GNOME 桌面共享', 'Current environment: GNOME desktop sharing')
+  if (linuxHyprlandSession.value) return t('当前环境：Hyprland 合成器输入', 'Current environment: Hyprland compositor input')
   const signature = signing.signature === 'adhoc'
     ? 'ad-hoc'
     : signing.signature === 'signed'
@@ -114,6 +118,9 @@ const signingDiagnostic = computed(() => {
   }
   if (linuxPortalSession.value) {
     return t('GNOME 会弹出系统桌面共享授权。授权后可截屏、按坐标点击和打字。这是整桌面级输入，不是单个窗口。停止或崩溃后键鼠仍归你。', 'GNOME shows a system desktop-sharing prompt. After you allow it, MilkSU can screenshot, click coordinates, and type. This is display-level input, not a single window. Keyboard and mouse stay yours after stop or crash.')
+  }
+  if (linuxHyprlandSession.value) {
+    return t('Hyprland 走合成器原生输入：桌面通知、截屏、按坐标点击和打字。这是整块桌面，不是单个窗口，也不是 GNOME Portal。停止或崩溃后键鼠仍归你。', 'Hyprland uses compositor-native input: a desktop notice, screenshot, coordinate clicks, and typing. This is the whole desktop, not a single window, and not the GNOME Portal. Keyboard and mouse stay yours after stop or crash.')
   }
   if (signing.stableIdentity) {
     return t(`${signingIdentityLabel.value}，权限应绑定到稳定 App 身份。`, `${signingIdentityLabel.value}. Permissions should bind to a stable app identity.`)

--- a/app/src/components-vue/CodingComputerUsePanel.vue
+++ b/app/src/components-vue/CodingComputerUsePanel.vue
@@ -270,11 +270,13 @@ const primarySetupAction = computed<{
   if (readyForCurrentTask.value) {
     return {
       label: t('停止可见会话', 'Stop visible session'),
-      detail: effectiveTarget.value
-        ? matchingOperationEvidence.value
-          ? t(`最近真实操作：${matchingOperationEvidence.value.summary}`, `Latest real action: ${matchingOperationEvidence.value.summary}`)
-          : t(`已锁定 ${effectiveTarget.value.name} · PID ${effectiveTarget.value.pid} · Window ${effectiveTarget.value.windowId}；下一步需要 Agent 对该窗口执行一次可见操作并保留工具结果。`, `Locked to ${effectiveTarget.value.name} · PID ${effectiveTarget.value.pid} · Window ${effectiveTarget.value.windowId}. Next, the agent needs to perform one visible action on this window and keep the tool result.`)
-        : t('已锁定当前 Coding 任务。', 'Locked to the current Coding task.'),
+      detail: linuxHyprlandSession.value
+        ? t('停止后会销毁 Hyprland 虚拟指针并交还键鼠。不是 Portal，也不会留下合成输入。', 'Stop destroys the Hyprland virtual pointer and returns the keyboard and mouse. This is not Portal, and no synthetic input stays behind.')
+        : effectiveTarget.value
+          ? matchingOperationEvidence.value
+            ? t(`最近真实操作：${matchingOperationEvidence.value.summary}`, `Latest real action: ${matchingOperationEvidence.value.summary}`)
+            : t(`已锁定 ${effectiveTarget.value.name} · PID ${effectiveTarget.value.pid} · Window ${effectiveTarget.value.windowId}；下一步需要 Agent 对该窗口执行一次可见操作并保留工具结果。`, `Locked to ${effectiveTarget.value.name} · PID ${effectiveTarget.value.pid} · Window ${effectiveTarget.value.windowId}. Next, the agent needs to perform one visible action on this window and keep the tool result.`)
+          : t('已锁定当前 Coding 任务。', 'Locked to the current Coding task.'),
       action: 'stop',
       variant: 'outline',
       disabled: props.loading || props.running,
@@ -318,7 +320,11 @@ const primarySetupAction = computed<{
   }
   return {
     label: t('启动可见会话', 'Start visible session'),
-    detail: t(`${effectiveTarget.value.name} 将被锁定为当前任务 Scope；${approvalGuidance.value}`, `${effectiveTarget.value.name} will be locked as this task’s scope. ${approvalGuidance.value}`),
+    detail: linuxHyprlandSession.value
+      ? t('将控制整块 Hyprland 桌面：截屏、坐标点击和打字。不是单个窗口，也不是 GNOME Portal。桌面会显示通知。没有这步点击不会创建虚拟指针。', 'This controls the whole Hyprland desktop: screenshot, coordinate clicks, and typing. Not a single window, and not the GNOME Portal. The desktop shows a notice. No click here means no virtual pointer.')
+      : linuxPortalSession.value
+        ? t('GNOME 会弹出系统桌面共享。授权后是整桌面截屏、点击和打字，不是单个窗口。', 'GNOME shows a system desktop-sharing prompt. After you allow it, screenshot, click, and type are display-level, not a single window.')
+        : t(`${effectiveTarget.value.name} 将被锁定为当前任务 Scope；${approvalGuidance.value}`, `${effectiveTarget.value.name} will be locked as this task’s scope. ${approvalGuidance.value}`),
     action: 'start',
     variant: 'brand',
     disabled: !canStart.value,

--- a/app/src/components-vue/SettingsPage.test.ts
+++ b/app/src/components-vue/SettingsPage.test.ts
@@ -783,6 +783,70 @@ describe('SettingsPage database compatibility', () => {
     expect(permissionRequests).toEqual(['accessibility', 'screen-recording'])
   })
 
+  it('describes Hyprland Computer Use as compositor-native and not Portal', async () => {
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'browser',
+      appMethods: {
+        GetCodingComputerUseStatus: async () => ({
+          available: true,
+          enabled: false,
+          phase: 'disabled',
+          permissions: {
+            accessibility: true,
+            screenRecording: true,
+          },
+          signing: {
+            bundleId: 'com.milksu.app',
+            signature: 'linux-hyprland',
+            stableIdentity: true,
+          },
+        } satisfies CodingComputerUseStatus),
+      },
+    })
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Hyprland 合成器')
+    expect(text).toContain('合成器原生输入')
+    expect(text).toContain('不是 GNOME Portal')
+    expect(text).toContain('不是单个窗口')
+    expect(text).not.toContain('启动任务时 GNOME 会弹出授权')
+    expect(text).not.toContain('打开辅助功能设置')
+  })
+
+  it('keeps GNOME Portal Computer Use as desktop sharing', async () => {
+    await mountSettingsPage({
+      directory: 'MilkSU 用户数据目录',
+      fileCount: 0,
+      bytes: 0,
+    }, {
+      initialCategory: 'browser',
+      appMethods: {
+        GetCodingComputerUseStatus: async () => ({
+          available: true,
+          enabled: false,
+          phase: 'disabled',
+          permissions: {
+            accessibility: true,
+            screenRecording: true,
+          },
+          signing: {
+            bundleId: 'com.milksu.app',
+            signature: 'linux-portal',
+            stableIdentity: true,
+          },
+        } satisfies CodingComputerUseStatus),
+      },
+    })
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('桌面共享')
+    expect(text).toContain('GNOME 会弹出授权')
+    expect(text).toContain('不是单个窗口')
+    expect(text).not.toContain('Hyprland 合成器')
+  })
+
   it('shows Browser Use, CTF sites, and Computer Use as setting rows', async () => {
     await mountSettingsPage({
       directory: 'MilkSU 用户数据目录',

--- a/app/src/components-vue/SettingsPage.vue
+++ b/app/src/components-vue/SettingsPage.vue
@@ -1996,6 +1996,14 @@ async function saveProviderEditor(closeAfterSave: boolean) {
             >
               <ConnectionLiveStatus :live="true" />
             </SettingsRow>
+            <SettingsRow
+              v-else-if="computerUseStatus?.signing?.signature === 'linux-hyprland'"
+              :label="t('Hyprland 合成器', 'Hyprland compositor')"
+              :description="t('启动任务时 Hyprland 会显示桌面通知。截屏、按坐标点击和打字走合成器原生输入，不是 GNOME Portal，也不是单个窗口。', 'Hyprland shows a desktop notice when you start a task. Screenshot, coordinate clicks and typing use compositor-native input, not the GNOME Portal, and not a single window.')"
+              :divider="false"
+            >
+              <ConnectionLiveStatus :live="computerUseStatus.available" />
+            </SettingsRow>
             <template v-else-if="computerUseStatus">
               <SettingsRow :label="t('辅助功能', 'Accessibility')">
                 <div class="flex items-center gap-2">

--- a/docs/architecture/current-system.md
+++ b/docs/architecture/current-system.md
@@ -57,7 +57,7 @@ MilkSU 的桌面壳不是通用 Agent Loop 的另一份实现。Pi 仍负责会�
 | --- | --- | --- | --- |
 | 浏览器 | MilkSU 管理的会话隔离 `WebContentsView` | 同一页面、地址、导航、当前会话与停止动作 | 不是外部 Chrome，不复用用户日常登录态 |
 | Browser Use | 用户真实 Chrome/Edge 中明确选择的标签页 | Composer 中可删除的标签页 Scope、配对状态与撤销入口 | 不获得整个 Profile，也不替代 CTF 平台 Judge |
-| Computer Use | macOS / Windows：明确选择的外部 App / PID / Window；Linux GNOME：整桌面 Portal | 可见 Scope、系统权限状态、运行轨迹与停止动作 | 像素级操作不替代隔离浏览器或 Browser Use；Linux 不是窗口 Scope，Hyprland / Xorg unavailable |
+| Computer Use | macOS / Windows：明确选择的外部 App / PID / Window；Linux GNOME：整桌面 Portal；Linux Hyprland：整桌面合成器原生输入 | 可见 Scope、系统权限状态、运行轨迹与停止动作 | 像素级操作不替代隔离浏览器或 Browser Use；Linux 不是窗口 Scope；GNOME 与 Hyprland 是两条合同，Xorg unavailable |
 
 三种表面还共享一个生命周期不变量：**面板显隐只改变观察视图，不改变执行 Session**。右栏折叠、
 切换页面或用户回到聊天区时，已授权任务不应因此停止；用户重新展开后应看到同一会话的最新状态。
@@ -79,7 +79,7 @@ MilkSU 的桌面壳不是通用 Agent Loop 的另一份实现。Pi 仍负责会�
 | 安全工具目录 | **Verified setup chain / real binary task pending** | “设置 → MCP”内置行使用真实 Desktop RPC 检测与持久化。IDA Pro/idalib 和 capa 具备可准备的固定版本适配器；就绪且启用后进入普通 Coding 的模型可选目录。用户可覆盖 command/args 或打开专用 Coding 工作区用自然语言改配置，并可恢复当前版本出厂默认。capa 仍是 `capa_analyze`，不是假 MCP。CodeQL、Burp Suite、Shannon 目前仅做本机/前提检测，不会被误报为模型可用。尚未用真实 crackme/二进制完成任务回执。当前也还没接到 CTF/CVE；需要时按切片接入，不必先等 Coding 回执再开会决定。 |
 | 内置浏览器 | **Verified packaged tasks; multi-tab in 26.818.2; Go auto-start removed in 26.819.1** | 产品 UI 只显示“浏览器”。每次 Coding 会话使用独立 `session.fromPath`，默认拒绝页面权限。`26.817.1` 起已有打包任务：Grok 只用浏览器完成顺序点击、表单提交和公开文档调研，右栏折叠后继续并保留同一页面终态。`26.818.2` 起标签栏 `+` 在启动前可见；每个标签是独立 `WebContentsView`，切换换页并更新地址。`26.819.1` 起隔离浏览器只在用户打开右栏或模型调用类型化 `milksu_workspace` 浏览器动作时启动；普通 Go 问候不再 `EnsureCodingBrowser`。`ScopedCDPProxy` 仍只公布当前一个 Target。 |
 | Browser Use | **Implemented UI / live pairing pending** | 真实用户 Chrome/Edge 复用固定 `@playwright/mcp --extension`，由用户选择准确标签页；不复用内置浏览器 profile。Linux / Windows 另查找本机 Chromium 家族（PATH、snap、Nix、桌面入口）；`v26.827.1` 已打入该查找路径，桌面配对回执仍待用户机。 |
-| Computer Use | **Verified self-bootstrap slice; Windows bounded driver packaged in 26.818.2; Linux GNOME Portal packaged in 26.827.1** | macOS / Windows 只接受外部可见 App/PID/Window Scope，含用户真实浏览器窗口；Calculator 与 Stable → MilkSU Beta 的 branch/commit/tracking 核验、click/scroll 及 CTF/CVE 任务连续性全程已验。Stable 排除自身；隔离浏览器与 Browser Use 仍是独立表面。任务授权可恢复，明确请求且只有一个合格目标时自动启动，准备期间的提交在就绪后自动续发，多目标仍需准确选择。右栏诊断和操作证据默认折叠。`26.818.2` Windows 包打入有界会话、宿主 PID 排除和审阅过的 `cua-driver 0.14.2`。Driver 先走安装包/Sidecar；缺失时由类型化 `prepare_computer_use_driver` 准备 MilkSU 审阅副本，不走 Cua 官方安装脚本。Linux 按桌面会话：GNOME Wayland 走 XDG Desktop Portal（整桌面级，不是窗口 Scope），已进入 `v26.827.1`；Hyprland 与 Xorg unavailable，不走 `xinput`。ISSUE #19 已关闭。 |
+| Computer Use | **Verified self-bootstrap slice; Windows bounded driver packaged in 26.818.2; Linux GNOME Portal packaged in 26.827.1; Hyprland compositor backend implemented on development HEAD** | macOS / Windows 只接受外部可见 App/PID/Window Scope，含用户真实浏览器窗口；Calculator 与 Stable → MilkSU Beta 的 branch/commit/tracking 核验、click/scroll 及 CTF/CVE 任务连续性全程已验。Stable 排除自身；隔离浏览器与 Browser Use 仍是独立表面。任务授权可恢复，明确请求且只有一个合格目标时自动启动，准备期间的提交在就绪后自动续发，多目标仍需准确选择。右栏诊断和操作证据默认折叠。`26.818.2` Windows 包打入有界会话、宿主 PID 排除和审阅过的 `cua-driver 0.14.2`。Driver 先走安装包/Sidecar；缺失时由类型化 `prepare_computer_use_driver` 准备 MilkSU 审阅副本，不走 Cua 官方安装脚本。Linux 按桌面会话：GNOME Wayland 走 XDG Desktop Portal（整桌面级，不是窗口 Scope），已进入 `v26.827.1`；开发 HEAD 上 Hyprland 走独立合成器后端（IPC + grim + wtype + zwlr_virtual_pointer），不是 Portal，也不是窗口 Scope，真机验收未做，未进 `v26.905.2`；Xorg unavailable，不走 `xinput`。ISSUE #19 已关闭。 |
 | CTF Runtime | **Implemented / Daily receipt partial** | `internal/ctf` 持有 Challenge、Evidence、Candidate、Judge Receipt、Recovery、Memory 与学习事实；模型候选不能建立成功事实。CTF 通用文件与 Shell 复用 Pi 原生工具及用户系统权限，不再复制 workspace-only 沙箱；MilkSU 只保留题目域工具、精确站点能力、凭据隔离、Judge 和证据投影。模型输出达到长度上限时通过 Pi `agent_end` / `followUp` 扩展点继续。Daily 由规则筛选未完成候选，再复用 Pi 结合近期题目、关联 Coding 对话、已确认事实和 Memory 选择并解释；结果按本地日期固定并允许主动换题，模型不可用时规则兜底。代码与自动化已回归，真实签名包用户视角仍待复验。 |
 | CVE Learning / Tracking | **Verified signed tracking slice; reproduction dossier in 26.822.1; public feeds in 26.823.1** | 用户界面只显示明确加入的公开 CVE、手工状态，默认文案为“想研究”。添加入口通过只读 Desktop RPC 搜索 NVD，用户选中后直接把当前结果和来源元数据写入本地追踪，不做第二次网络请求；参考资料按机构去重，完整集合仍由 NVD 承载。学习专题已从 CVE 页删除，同类搜索改走列表右上角「导入」弹窗。`26.822.1` 点进档案后复现：Agent 编辑 `report.md`，对话留在右下角小窗。`26.823.1` 起「同步公开源」写入的 CISA KEV 条目会进入列表。不以「复现成功 / 没复现上」当完成面。披露草稿还没做，不是禁令。 |
 | Obelisk / 记忆底座 | **Implemented backend / UI deferred** | MilkSU 自有索引仍只处理本机 Coding/CTF/CVE 会话；当前产品不展示单会话历史面板或图谱。后续学习记录/记忆系统应作为独立页面进入，不移除或混写 Obelisk 与 CTF Memory 底层事实。 |
@@ -301,6 +301,6 @@ DEB 与 tar.gz 已在原生 Ubuntu 完成包结构、Node/Pi Sidecar、Go Runtim
 后续正式包应走 `release:verify` → 云端 macOS / Windows / Linux → `release:github` 创建 Release 页。
 
 Linux `v26.905.2` 包已包含当前 CTF/CVE 与通用 Coding 的 Pi Runtime 收敛、共用 tarball / PKGBUILD / Nix flake，
-以及 GNOME Portal Computer Use；仍不接 Secret Service 与本地 OCR，Hyprland / Xorg Computer Use unavailable。
+以及 GNOME Portal Computer Use；仍不接 Secret Service 与本地 OCR。开发 HEAD 另有 Hyprland 合成器 Computer Use，未进该正式包，也不能写成与 GNOME Portal 等价；Xorg Computer Use unavailable。
 Windows 未签名和 Linux 缺失能力必须在下载说明中明确，不能把三端构建
 回执外推为三个平台功能等价。OTA 草稿应已上传私有 R2；Admin current pointer 仍须维护者在「版本」页发布。

--- a/docs/developer/TRY-hyprland-computer-use.md
+++ b/docs/developer/TRY-hyprland-computer-use.md
@@ -1,0 +1,90 @@
+# 试跑：Hyprland Computer Use
+
+> 给明早 Omarchy / Hyprland 本机用。这是开发线，**不是** GitHub Latest `v26.905.2`。
+> 正式包里 Hyprland 仍 unavailable。必须 checkout 本分支后构建。
+>
+> 本 Cloud Agent 没有 Omarchy/Hyprland 真机。下面步骤要在真实 Hyprland 会话里做。
+
+独立合同：这条后端不是 GNOME Portal，也不是窗口 Scope。它控制**整块 Hyprland 桌面**。
+
+禁止：`xinput`、uinput、`/dev/input`、Cua Linux 安装脚本。
+
+## 1. 检出本分支
+
+```bash
+git fetch origin cursor/hyprland-computer-use-51e1
+git checkout cursor/hyprland-computer-use-51e1
+```
+
+确认 `git rev-parse --short HEAD` 不是 `b18b860`（那是 `v26.905.2`）。
+
+## 2. 本机依赖
+
+在 **Hyprland 图形会话**里（不要只开 SSH 无 Wayland）：
+
+```bash
+echo "$HYPRLAND_INSTANCE_SIGNATURE"
+echo "$XDG_CURRENT_DESKTOP"
+echo "$WAYLAND_DISPLAY"
+command -v hyprctl grim wtype
+```
+
+缺 grim / wtype：
+
+```bash
+sudo pacman -S grim wtype
+```
+
+`hyprctl` 随 Hyprland。不要装 ydotool，不要跑 Cua 官方 installer。
+
+## 3. 构建并启动开发桌面
+
+```bash
+npm install
+npm --prefix app install
+go test ./internal/computercap/
+npm run desktop:start
+```
+
+已有本机 tarball / 自构建包时，也可以换成该二进制，但必须是本分支打出来的，不能是 `MilkSU-Linux-x64-26.905.2.tar.gz`。
+
+Wayland 下如窗口不出现，等 5 秒；Linux 会补一次 `show()`。
+
+## 4. 确认后端身份
+
+设置 → Computer Use：
+
+- 应看到 **Hyprland 合成器**
+- 说明里有「合成器原生输入」「不是 GNOME Portal」「不是单个窗口」
+- LIVE
+- **不要**出现「GNOME 会弹出授权」或「桌面共享」
+
+缺 grim/wtype 时这里会点名缺包，先回到第 2 步。
+
+## 5. 可见同意 → 截屏 / 点击 / 打字
+
+1. 打开 Coding，打开 Computer Use 面板。
+2. 诊断应写：整块桌面、合成器原生、不是 Portal、停止后键鼠归你。
+3. 点 **启动可见会话**。没有这步点击，不会创建虚拟指针。
+4. 桌面应出现 Hyprland 通知：Computer Use 已开始。
+5. 让 Agent 或工具走一遍：截屏 → 坐标点击 → 打字。
+6. 点 **停止可见会话**。
+7. 桌面通知「键鼠已交还」。鼠标键盘立刻回到你手里。没有残留合成指针。
+
+## 6. 失败时看什么
+
+| 现象 | 原因 |
+| --- | --- |
+| 设置仍写 Hyprland 暂不可用 | 跑的是 `v26.905.2` 或未切到本分支 |
+| 设置写 GNOME 桌面共享 | 当前会话是 GNOME，不是 Hyprland |
+| 缺少 grim / wtype | `pacman -S grim wtype` |
+| 无法创建虚拟指针 | 合成器未提供 `zwlr_virtual_pointer`；不会回退 Portal 或 xinput |
+| 启动后没有通知 | 仍检查面板文案；通知失败不阻止会话，但应能停止并交还键鼠 |
+
+## 7. 验收勾选（真人）
+
+- [ ] 不是 `v26.905.2` 正式包
+- [ ] 设置显示 Hyprland 合成器，不是 Portal
+- [ ] 启动前必须点「启动可见会话」，桌面有通知
+- [ ] 截屏、坐标点击、打字各一次
+- [ ] 停止后键鼠立刻可用，没有 xinput detach

--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -32,8 +32,8 @@
 | 历史基线 | M3 product-loop 已在 `108e0e3`（2026-08-05）合并，仅供追溯。 |
 | 正式发行基线 | `v26.905.2 / b18b8607e2645c3977125e79d0257256951ae6b5`（2026-09-05 今日第二版）。这是当前 GitHub Latest Release；提供带版本号的 DMG、EXE、DEB、x64 tar.gz 与 `SHA256SUMS`。OTA 已上传私有 R2。侧栏下载先 `checkForUpdates` 再 `downloadUpdate`。已发出的 `26.827.1` / `26.904.1` / `26.905.1` 客户端改不了，这一跳请从 GitHub 下安装包。上一版 `v26.905.1 / 1cc8773`、`v26.904.1 / 6e9371d` 与 `v26.827.1 / 37932ce` 仍可下载，不是 Latest。 |
 | 开发版本线 | 根目录与 `desktop/package.json` 是 `26.905.2`。正式发行源是 `b18b860`；文档收口提交不移动该 tag。 |
-| 当前开发 | 正式包是 `26.905.2`。Composer 上下文环按 Pi 组装分类；设置页可查看并覆盖模型上下文窗口。edit 锚点、`tool_result` 截断、中途引导、子 Agent 结构化回传、rewind/handoff、用户 MCP/Skills 与克制清透材料层已进包。侧栏下载先 check 再 download，失败可见重试。三端窗口铬：macOS 保持 `hiddenInset`，Windows/Linux 隐藏原生标题栏并用画布色 overlay。已登录 Stable 轮询 Admin 时带上当前版本。实验室题目包仍可起本机 Docker / MilkSU-Lab。Pi 钉到 `0.84.1`。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；Hyprland/Xorg Computer Use 不可用。CTF 比赛模式和实验室红队学习面仍未接线。产品 UI 设计语言只写在 `AGENTS.md`。未发版：`fix/wide-job-parent-loop` 给 parent loop 加上 `bg_status` poller 熔断，并把 `subagent` 从「用户开口才调用」改回最多 4 条 read-only lane；#53 的 typed sweep 工具尚未做。 |
-| 平台边界 | `26.905.2`：macOS DMG 走 GitHub-hosted Developer ID 签名并公证；Windows 安装器完成原生 Runtime 与首次启动但未代码签名，并打入审阅过的 CUA Driver；Linux 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball，GNOME Portal Computer Use 已进包，仍无 Secret Service、本地 OCR；Hyprland/Xorg Computer Use 不可用。Windows/Linux 窗口铬尚未真机验收。 |
+| 当前开发 | 正式包是 `26.905.2`。Composer 上下文环按 Pi 组装分类；设置页可查看并覆盖模型上下文窗口。edit 锚点、`tool_result` 截断、中途引导、子 Agent 结构化回传、rewind/handoff、用户 MCP/Skills 与克制清透材料层已进包。侧栏下载先 check 再 download，失败可见重试。三端窗口铬：macOS 保持 `hiddenInset`，Windows/Linux 隐藏原生标题栏并用画布色 overlay。已登录 Stable 轮询 Admin 时带上当前版本。实验室题目包仍可起本机 Docker / MilkSU-Lab。Pi 钉到 `0.84.1`。Windows 安装器仍未代码签名；Linux 无 Secret Service 与本地 OCR；Xorg Computer Use 不可用。开发 HEAD 已为 Hyprland 增加独立合成器 Computer Use 后端，真机验收未做，未进 `26.905.2`。CTF 比赛模式和实验室红队学习面仍未接线。产品 UI 设计语言只写在 `AGENTS.md`。未发版：`fix/wide-job-parent-loop` 给 parent loop 加上 `bg_status` poller 熔断，并把 `subagent` 从「用户开口才调用」改回最多 4 条 read-only lane；#53 的 typed sweep 工具尚未做。 |
+| 平台边界 | `26.905.2`：macOS DMG 走 GitHub-hosted Developer ID 签名并公证；Windows 安装器完成原生 Runtime 与首次启动但未代码签名，并打入审阅过的 CUA Driver；Linux 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball，GNOME Portal Computer Use 已进包，仍无 Secret Service、本地 OCR；该正式包里 Hyprland/Xorg Computer Use 仍不可用。开发 HEAD 的 Hyprland 后端与 GNOME Portal 不是同一合同，也不能写成三桌面等价。Windows/Linux 窗口铬尚未真机验收。 |
 | 发行流水 | 下一发行从干净、已推送的 `main` 对 canonical Go/Vue/Sidecar/lint/生产与文档构建只验证一次；macOS / Windows / Linux 都走 GitHub-hosted 云端。macOS 本机打包暂时关闭。必须创建 GitHub Release 页并上传带版本号的 DMG/EXE/DEB、x64 tar.gz 与 SHA256SUMS，不能只留空 tag。正式打包默认上传 OTA 到私有 R2 并建 Admin 草稿；GitHub Release 仍不上 updater ZIP。 |
 
 ## 已发行改动：`26.817.1` → `26.905.2`
@@ -170,12 +170,13 @@
 
 ## 未发版改动：晚于 `v26.905.2` / `b18b860`
 
-文档收口提交不移动该 tag。Windows 代码签名、Linux Secret Service / 本地 OCR、Hyprland/Xorg Computer Use 仍缺。CTF 比赛模式和实验室红队学习面仍未接线。
+文档收口提交不移动该 tag。Windows 代码签名、Linux Secret Service / 本地 OCR、Xorg Computer Use 仍缺。Hyprland Computer Use 已在开发线接线（合成器原生，不是 Portal），Omarchy/Hyprland 真机验收未做。CTF 比赛模式和实验室红队学习面仍未接线。
 
 - 流式回复只保留实心 caret，不再把最后约 6 个字做成模糊尾；CJK 在 Windows 上不再发虚。
 - 侧栏运行中会话只显示像素点，`运行中` 留在 `aria-label`。原先可见文案在 16px 状态槽里居中裁切，会露出中间的「行」。
 - 计划 / 变更上拉框不再跟收缩后的胶囊同宽；展开后最小 18rem，步骤文案不再只剩两个字。
 - 下拉框、菜单、Dialog、Sheet 和对话小窗改用实底 `--surface-overlay` / `--popover`，不再套 68–74% 透明加 `backdrop-filter`。Windows 上 blur 经常不生效，字会看穿。Composer 岛仍可保留轻模糊。
+- Hyprland Computer Use 改为独立合成器后端：检测 `HYPRLAND_INSTANCE_SIGNATURE` / 桌面会话后走 Hyprland IPC、`grim` 截屏、`zwlr_virtual_pointer` 点击和 `wtype` 打字；GNOME 仍只走 Portal。不接 Cua Linux 驱动，不走 `xinput`。单元测试覆盖路由；真实 Omarchy/Hyprland 机器验收仍缺，不能写成已发行。
 
 ## 当前产品事实
 
@@ -240,7 +241,7 @@
 3. 继续用新安装包做常用 Agent GUI、Pi Runtime 与实验室靶机回归，失败项回到下面 P0 队列；
 4. 用户明确要求发下一版时，先升版本号，再从干净已推送的 `main` 跑 `release:verify` 并留下新的三端回执；不要把现有 `v26.905.2`、`v26.905.1`、`v26.904.1` 或 `v26.827.1` 标签挪到更新的 HEAD 上。
 
-Windows 签名、Linux Secret Service / OCR、Hyprland/Xorg Computer Use、Windows/Linux 窗口铬真机验收仍是发行后续，不是产品方向禁令。
+Windows 签名、Linux Secret Service / OCR、Xorg Computer Use、Hyprland 真机验收、Windows/Linux 窗口铬真机验收仍是发行后续，不是产品方向禁令。
 
 ### 后续队列
 

--- a/docs/developer/document-status.md
+++ b/docs/developer/document-status.md
@@ -28,7 +28,7 @@
 | 开发版本线 | 仓库版本为 `26.905.2`。正式发行源是 `b18b860`；文档收口提交不移动该 tag。 |
 | 许可证 | 主项目为 `AGPL-3.0-only`（`LICENSE` / `NOTICE`）。第三方仍保留原许可。Obelisk 作为计划嵌入的 AGPL 记忆组件与此兼容；尚未 vendored。 |
 | 三端正式发行 | GitHub Latest Release `v26.905.2` 已提供签名并公证的 macOS ARM64 DMG、未签名 Windows x64 EXE、Linux x64 DEB 与 x64 tar.gz，以及 `SHA256SUMS-26.905.2.txt`。OTA 已上传私有 R2。`26.905.2` 侧栏下载先 `checkForUpdates` 再 `downloadUpdate`。从更早正式包到本版请下 GitHub 安装包。 |
-| Linux | `26.905.2` 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball；GNOME Wayland Computer Use 走 Portal。仍无 Secret Service、本地 OCR；Hyprland / Xorg Computer Use unavailable。ISSUE #19 已关闭（拒绝 X11 xinput）。合同见 [Linux 安装与桌面合同](linux-platform-support.md)。 |
+| Linux | `26.905.2` 发出 Ubuntu/Debian 共用 x64 DEB 与 Omarchy/Arch/Nix 共用 x64 tarball；GNOME Wayland Computer Use 走 Portal。仍无 Secret Service、本地 OCR；该正式包里 Hyprland / Xorg Computer Use unavailable。开发 HEAD 为 Hyprland 增加独立合成器后端（单元测试已覆盖；真机验收未做）。ISSUE #19 已关闭（拒绝 X11 xinput）。合同见 [Linux 安装与桌面合同](linux-platform-support.md)。 |
 | Agent Harness | Pi 拥有 Session、Compaction、自然语言理解、通用文件/Shell 与 Tool Loop。MilkSU 已删除 workspace-only 文件工具、Node 文件权限状态机、普通回合 watchdog、CTF sandbox-exec、CVE 只读启动限制与客服式回复模板。不扫描用户句子做关键词/正则意图路由。`26.823.1` 起 Coding/CTF/CVE/实验室共用完整 Coding loop（含压缩、终端、Git、浏览器、LSP、Goal），领域工具叠在上面而不是替换；工具结果进模型前截断到 Pi 的 50KB/2000 行。`26.905.1` 起产品工具 when-to-use 不再在 system prompt 复述一遍；`release-milksu` 对模型名录隐藏。渐进披露跟当前选中的 Agent Harness 走，不跟 MilkSU 自造注入器走。 |
 | 上下文工程 | `26.825.1` 把经监督器校验的主会话 cwd 明确注入 Pi；writer worktree 仅属于独立 effectful subagent。Sidecar 通过 Pi 原生长缓存保留复用稳定会话前缀，压缩仍禁用一次性缓存写入。`26.904.1` 起窗口优先级为手动覆盖 > catalog（忽略 `128000` 占位）> 型号族预设 > 保守默认；Composer 环按 Pi 组装分类，并落地 edit 锚点、`tool_result` bound、中途引导与子 Agent 结构化回传。`26.905.1` 接线 `/rewind` 与最后一条用户消息的「丢掉这段」（Pi `navigateTree`）、`/handoff` 与用量环「接到新会话」（Pi 分叉 + 现行 compact）。GPT 与 Claude Opus / Sonnet / Fable 使用思考档位预设，其他模型在设置中手动声明；Composer 的对话级离散滑块只显示标准英文档位，经 Go 约束后调用 Pi 原生档位，最高为 `max`，子 Agent 同步继承。自动化已通过，真实 Provider 缓存命中率与 effort 请求仍待用户授权的计费链路验收。 |
 | MilkSU 宿主边界 | 只保留会话目录记录、Provider 凭据隔离、桌面授权、领域事实/Judge，以及危险大目录删除二次确认。Coding 另有类型化 `milksu_workspace` 与对话级批准，不替代 Pi 工具循环。 |
@@ -44,7 +44,7 @@
 | --- | --- | --- | --- |
 | [当前开发目标](current-objectives.md) | Current / Canonical | 当前阶段、正式发行基线、开发版本线、已发行/未发版事实、下一完成线和未接线方向 | 不保存完整聊天、微提交或旧验收过程；不复述 UI 规范 |
 | [当前系统与分层](../architecture/current-system.md) | Current / Canonical | 当前运行结构、依赖方向、桌面表面、能力边界和发行结构 | 不安排任务优先级；不复述 UI 规范 |
-| [Linux 安装与桌面合同](linux-platform-support.md) | Target / Designed | 共用 x64 DEB + 通用 tarball；ARM 只测不发；GNOME Portal Computer Use；ISSUE #19 已关闭 | 不把未发版安装面写成 GitHub Latest；不按 arch×distro 发 8 份包 |
+| [Linux 安装与桌面合同](linux-platform-support.md) | Target / Designed | 共用 x64 DEB + 通用 tarball；ARM 只测不发；GNOME Portal 与 Hyprland 合成器是两条 Computer Use 合同；ISSUE #19 已关闭 | 不把未发版安装面写成 GitHub Latest；不按 arch×distro 发 8 份包；不把三桌面写成功能等价 |
 | 仓库根目录 `AGENTS.md` | Current / Canonical | 仓库协作约束与产品 UI 设计语言 | 其他文档只指向它，不复制层级、token 或原语表 |
 | 本文件 | Current / Living | 事实优先级、文档职责、生命周期和维护规则 | 不复制实现细节或测试日志 |
 | Evidence 文档 | Evidence | 可复现命令、截图、哈希、平台回执和失败证据 | 不自动升级为当前完成状态 |

--- a/docs/developer/linux-platform-support.md
+++ b/docs/developer/linux-platform-support.md
@@ -91,6 +91,8 @@ GNOME Portal 只承诺显示器级输入，产品文案必须写明，不得冒�
 
 验证脚本：`scripts/verify-linux-deb-debian13.sh`、`scripts/verify-linux-pacman-arch.sh`、`scripts/verify-linux-nixos.sh`。容器安装成功不是 GNOME/Hyprland 真机 GUI 回执。Xvfb、一次截图或 Portal 在线都不能替代真实桌面回执。
 
+开发线 Hyprland 本机试跑步骤见 [TRY-hyprland-computer-use.md](TRY-hyprland-computer-use.md)。不要用 `v26.905.2` 正式包试。
+
 ## 尚未建立的事实
 
 - Debian 13 GNOME 与 Ubuntu 同类，本切片跳过独立 Debian GNOME 验收；

--- a/docs/developer/linux-platform-support.md
+++ b/docs/developer/linux-platform-support.md
@@ -4,7 +4,7 @@
 >
 > 目标范围：Ubuntu 24.04、Debian 13、Omarchy、当前仍受支持的 NixOS stable
 >
-> 最后审阅：2026-08-26
+> 最后审阅：2026-09-06
 >
 > 本文记录 Linux 安装面与 Computer Use 的产品边界。它不是实施队列，也不把计划写成已验证能力。
 > 当前发行事实仍以 [当前开发目标](current-objectives.md)、[文档状态](document-status.md)、当前代码和真实平台回执为准。
@@ -19,13 +19,13 @@
 3. 正式发行架构仍是 `linux/amd64`。Apple Silicon 上的 ARM 虚拟机只作开发测试：ARM 上跑通后，同一代码打 x64 包。ARM DEB/tarball 可以留在本机或 CI 试验产物里，不进入 GitHub Latest。
 4. Ubuntu 与 Debian 共用那份 `.deb`，不能假定 Ubuntu-only 包名。Omarchy / NixOS 不要求用户拆 DEB。
 5. ISSUE [#19](https://github.com/MilkSU-Official/milksu/issues/19) 已关闭：X11 `cua-driver --permission-mode bounded` 与 `xinput detach/disable` 拒绝合入。Linux 产品代码不运行 `xinput detach/disable`，不把 root/uinput 或 `/dev/input` 做成隐式后门，也不接入 Cua Linux 驱动。Xorg 会话 Computer Use 保持 unavailable。若以后做 X11，另开 XTEST 合成事件的 issue，不复活摘设备路径。
-6. GNOME Wayland 的宿主 Computer Use 走 XDG Desktop Portal 最小路径：系统授权框、截屏、按坐标点击、打字；停止或崩溃后物理键鼠仍归用户。这是整桌面级输入，不能写成 macOS/Windows 那种精确窗口 Scope。Hyprland 在上游 RemoteDesktop 可依赖之前保持 unavailable。
+6. GNOME Wayland 的宿主 Computer Use 走 XDG Desktop Portal 最小路径：系统授权框、截屏、按坐标点击、打字；停止或崩溃后物理键鼠仍归用户。这是整桌面级输入，不能写成 macOS/Windows 那种精确窗口 Scope。Hyprland 走独立的合成器原生后端（Hyprland IPC + `grim` / `wtype` + `zwlr_virtual_pointer`），不复用 GNOME Portal，也不等待 `xdg-desktop-portal-hyprland` 的 RemoteDesktop。产品文案必须写明这两条合同不同。
 7. NixOS 没有 Ubuntu 式 LTS。flake 随当时仍受支持的 nixpkgs 通道重验。Omarchy 是滚动发行，安装面随官方包仓走。
-8. 嵌套 Wayland session、Hyprland 私有协议后端、CDP 附着外部 Electron App，都不是本安装合同的一部分。
+8. 嵌套 Wayland session、CDP 附着外部 Electron App，都不是本安装合同的一部分。Hyprland Computer Use 只使用合成器已公开的 IPC、截屏工具和 Wayland 虚拟指针协议，不接 Cua Linux 驱动，不走 `xinput`。
 
 ## 当前事实
 
-正式发行 `v26.904.1` 的 Linux 产物是 Ubuntu/Debian 共用 x64 `.deb` 与 Omarchy/Arch/Nix 共用 x64 `.tar.gz`。自动化验证了包结构、Node/Pi Sidecar、Go Runtime 和 Xvfb Electron 启动。GNOME Wayland Computer Use 走 XDG Desktop Portal，已进包；Hyprland / Xorg unavailable。发布脚本明确记录 `localOcr: false`；Linux 仍无 Secret Service。
+正式发行 `v26.905.2` 的 Linux 产物是 Ubuntu/Debian 共用 x64 `.deb` 与 Omarchy/Arch/Nix 共用 x64 `.tar.gz`。自动化验证了包结构、Node/Pi Sidecar、Go Runtime 和 Xvfb Electron 启动。GNOME Wayland Computer Use 走 XDG Desktop Portal，已进该正式包。开发 HEAD 另有独立的 Hyprland 合成器后端（单元测试已覆盖路由）；Omarchy / 真机 Hyprland 验收尚未留下回执，不能写成已发行或与 GNOME Portal 功能等价。Xorg unavailable。发布脚本明确记录 `localOcr: false`；Linux 仍无 Secret Service。
 
 - Sidecar 只有 `linux/amd64` Node runtime；Linux 没有已审阅的 `@napi-rs/system-ocr` 原生包。
 - Browser Use 查找 Chrome / Chromium / Edge、PATH、snap、Nix 与桌面入口。
@@ -33,7 +33,7 @@
 
 本机 Apple Silicon QEMU 上的 Ubuntu 24.04 ARM64 GNOME Wayland 已看到：应用窗口、hicolor 图标（不再落到齿轮）、隔离浏览器，以及装上 Chromium 后的 Browser Use 可执行文件探测。换入本切片 Go/Sidecar 后，用户点允许桌面共享：会话 `ready`，坐标点击成功，打字写入系统设置搜索框（`milksu-portal`），停止后 Portal session 与 socket 消失、Mutter 可再 CreateSession。锁屏会抑制 RemoteDesktop。Screenshot 接口在该 virtio-gpu 上返回 code 2，画面改从已授权 ScreenCast 流取出。
 
-Debian 13 ARM64 Hyprland 0.55.2（trixie-backports，virtio-gpu）：tarball 应用在 `ozone-platform=wayland` 下启动，Hyprland `hyprctl clients` 可见 class `milksu`。Computer Use 为 unavailable，文案写明 Hyprland 暂不可用、不走 xinput。Hyprland 上 `ready-to-show` 可能不触发，Linux 会在 5 秒后 `show()`。这是试验回执，不是 GitHub Latest。
+Debian 13 ARM64 Hyprland 0.55.2（trixie-backports，virtio-gpu）：tarball 应用在 `ozone-platform=wayland` 下启动，Hyprland `hyprctl clients` 可见 class `milksu`。当时 Computer Use 为 unavailable。开发 HEAD 已改走独立 Hyprland 后端，但该 virtio 试验不是 Omarchy 真机回执，也不能改写 `v26.905.2`。Hyprland 上 `ready-to-show` 可能不触发，Linux 会在 5 秒后 `show()`。
 
 NixOS 26.05 ARM64 GNOME 图形 live（virtio-gpu）：同一 ARM tarball 经 `packaging/linux` flake/`default.nix` 的 FHS 包装后，在 Wayland 上启动并显示出登录页。FHS 需要 `libgbm`（以及 fontconfig / freetype / gdk-pixbuf / wayland），否则 Electron 会在加载 `libgbm.so.1` 时退出。从 SSH 会话拉起时不要带无授权的 `DISPLAY`；图形会话内用 `ozone-platform=wayland`。这是试验回执，不是 GitHub Latest。Computer Use 未在该 live 上单独点授权，GNOME 仍走同一 Portal 路径。
 
@@ -47,8 +47,8 @@ NixOS 26.05 ARM64 GNOME 图形 live（virtio-gpu）：同一 ARM tarball 经 `pa
 | --- | --- | --- | --- |
 | Ubuntu 24.04 · GNOME Wayland | 共用 `.deb` | 本切片 | Portal 最小路径（桌面级） |
 | Debian 13 · GNOME Wayland | 同一 `.deb` | `verify-linux-deb-debian13.sh` | 同上 |
-| Omarchy · Hyprland | 同一 `.tar.gz` + PKGBUILD | `verify-linux-pacman-arch.sh` | unavailable |
-| NixOS · GNOME 或 Hyprland | 同一 `.tar.gz` + flake | `verify-linux-nixos.sh` | GNOME 同 Portal；Hyprland unavailable |
+| Omarchy · Hyprland | 同一 `.tar.gz` + PKGBUILD | `verify-linux-pacman-arch.sh` | 开发线：合成器原生（整桌面，非 Portal）；真机验收未做 |
+| NixOS · GNOME 或 Hyprland | 同一 `.tar.gz` + flake | `verify-linux-nixos.sh` | GNOME 同 Portal；Hyprland 同左列开发线，真机验收未做 |
 
 Ubuntu / Debian 的 Xorg 会话只做负向验收：Computer Use 不走 `xinput`。Fedora、openSUSE、KDE、Sway 不在首轮承诺里；代码应按能力探测自然降级。
 
@@ -66,7 +66,7 @@ Ubuntu / Debian 的 Xorg 会话只做负向验收：Computer Use 不走 `xinput`
 
 ISSUE [#19](https://github.com/MilkSU-Official/milksu/issues/19) 已关闭：X11 后端拒绝合入；GNOME Wayland Portal 路径已通过停止后键鼠仍可用的验收。
 
-GNOME Portal 只承诺显示器级输入，产品文案必须写明，不得冒充 App/Window Scope。Hyprland 在上游 RemoteDesktop 可依赖前保持 unavailable。
+GNOME Portal 只承诺显示器级输入，产品文案必须写明，不得冒充 App/Window Scope。Hyprland 是另一条整桌面合同：合成器通知 + `grim` 截屏 + 虚拟指针点击 + `wtype` 打字；停止或崩溃后键鼠仍归用户。两条后端不得混写，也不能把三个 Linux 桌面写成功能等价。
 
 ## GitHub Release 上传清单
 
@@ -86,6 +86,7 @@ GNOME Portal 只承诺显示器级输入，产品文案必须写明，不得冒�
 - NixOS：`packaging/linux` flake 包装同一 unpacked 目录
 - 桌面：Wayland ozone auto；hicolor 16–512 图标；Browser Use 查找 Chromium 家族
 - GNOME Computer Use：XDG Desktop Portal 授权后截屏 / 坐标点击 / 打字，不接 Cua
+- Hyprland Computer Use：独立合成器后端；缺 grim/wtype 时产品指出要装的包；真机验收仍缺
 - 本机 ARM 虚拟机只验证，不改变正式包架构
 
 验证脚本：`scripts/verify-linux-deb-debian13.sh`、`scripts/verify-linux-pacman-arch.sh`、`scripts/verify-linux-nixos.sh`。容器安装成功不是 GNOME/Hyprland 真机 GUI 回执。Xvfb、一次截图或 Portal 在线都不能替代真实桌面回执。
@@ -96,7 +97,8 @@ GNOME Portal 只承诺显示器级输入，产品文案必须写明，不得冒�
 - Omarchy 官方 ISO 仍是 x86_64；ARM 上用 Debian 13 + Hyprland 0.55 做过 Wayland 试验，不是 Omarchy 发行面回执；
 - NixOS ARM GNOME live 已有 FHS 启动回执，仍没有正式 GitHub Release 回执；
 - Linux Secret Service 与本地 OCR 仍未实现；
-- Hyprland RemoteDesktop 尚未成为可依赖的正式上游能力，Computer Use 保持 unavailable；
+- Hyprland Computer Use 已在开发线实现并有单元测试；尚未在真实 Omarchy / Hyprland 机器留下截屏、点击、打字与停止后键鼠仍可用的回执；
+- `xdg-desktop-portal-hyprland` RemoteDesktop 仍不可依赖，因此 Hyprland 不走 Portal；
 - Linux ARM64 不是发行架构；
 - Portal 与通用 tarball 尚未进入 GitHub Latest `v26.825.1`。
 

--- a/internal/computercap/hyprland.go
+++ b/internal/computercap/hyprland.go
@@ -1,0 +1,113 @@
+package computercap
+
+// Hyprland Computer Use is a separate Linux host backend from GNOME's
+// XDG Desktop Portal path. xdg-desktop-portal-hyprland does not provide a
+// dependable RemoteDesktop surface, so this backend uses compositor-native
+// tools instead of pretending to be Portal window-scope:
+//
+//   hyprctl notify / monitors / movecursor
+//   grim screenshots
+//   wtype virtual keyboard
+//   zwlr_virtual_pointer_v1 clicks and scrolls
+//
+// Community hypruse documents the same stack. MilkSU does not vendor that
+// Python MCP server: it is a different product contract, and Computer Use
+// already has a reviewed host-socket protocol. Cua Linux installers and
+// xinput/uinput remain rejected (ISSUE #19).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	linuxHyprlandBundleID     = "org.hyprland.ComputerUse"
+	linuxHyprlandTargetName   = "Hyprland"
+	linuxHyprlandWindowID     = 1
+	linuxHyprlandSyntheticPID = 3
+	linuxHyprlandSignature    = "linux-hyprland"
+
+	linuxHyprlandPrepareNextStep = "启动 Computer Use 时，Hyprland 会显示桌面通知。截屏、按坐标点击和打字走合成器原生输入，不是 GNOME Portal，也不是单个窗口。"
+	linuxHyprlandToolsNextStep   = "用发行版软件包安装 grim 与 wtype。Arch/Omarchy：pacman -S grim wtype。hyprctl 随 Hyprland。不要运行 Cua 官方安装脚本，也不要使用 xinput。"
+)
+
+var hyprlandRequiredTools = []string{"hyprctl", "grim", "wtype"}
+
+func linuxHyprlandDesktopTarget() Target {
+	return Target{
+		Name:        linuxHyprlandTargetName,
+		BundleID:    linuxHyprlandBundleID,
+		PID:         linuxHyprlandSyntheticPID,
+		WindowID:    linuxHyprlandWindowID,
+		WindowTitle: linuxHyprlandTargetName,
+	}
+}
+
+func linuxHyprlandSigning() SigningStatus {
+	return SigningStatus{
+		BundleID:       defaultHostBundleID,
+		Signature:      linuxHyprlandSignature,
+		StableIdentity: true,
+	}
+}
+
+func defaultHyprlandTools() error {
+	return linuxHyprlandToolsReady(exec.LookPath)
+}
+
+func linuxHyprlandToolsReady(lookPath func(string) (string, error)) error {
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	missing := make([]string, 0, len(hyprlandRequiredTools))
+	for _, name := range hyprlandRequiredTools {
+		if forbiddenHostTool(name) {
+			return fmt.Errorf("Hyprland Computer Use 拒绝调用 %s", name)
+		}
+		if _, err := lookPath(name); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s", linuxHyprlandToolsProblem(missing))
+}
+
+func linuxHyprlandToolsProblem(missing []string) string {
+	if len(missing) == 0 {
+		missing = hyprlandRequiredTools
+	}
+	return "Computer Use 在 Hyprland 上还缺少 " + strings.Join(missing, "、") +
+		"。用发行版软件包安装 grim 与 wtype（hyprctl 随 Hyprland）。走合成器原生输入，不是 GNOME Portal。不会走 xinput，也不接 Cua。"
+}
+
+func forbiddenHostTool(name string) bool {
+	base := strings.ToLower(filepath.Base(strings.TrimSpace(name)))
+	switch base {
+	case "xinput", "ydotool", "dotool", "evemu-event":
+		return true
+	}
+	return strings.Contains(base, "uinput")
+}
+
+func hyprlandWaylandSocket(getenv func(string) string) (string, error) {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	display := strings.TrimSpace(getenv("WAYLAND_DISPLAY"))
+	if display == "" {
+		display = "wayland-1"
+	}
+	if filepath.IsAbs(display) {
+		return display, nil
+	}
+	runtimeDir := strings.TrimSpace(getenv("XDG_RUNTIME_DIR"))
+	if runtimeDir == "" {
+		return "", fmt.Errorf("当前没有 XDG_RUNTIME_DIR，无法连接 Hyprland Wayland 显示")
+	}
+	return filepath.Join(runtimeDir, display), nil
+}

--- a/internal/computercap/hyprland_session.go
+++ b/internal/computercap/hyprland_session.go
@@ -267,7 +267,7 @@ func parseHyprlandMonitorExtent(raw []byte) (int, int, bool) {
 }
 
 func hyprlandShotPath() (string, error) {
-	root := filepath.Join(hostpath.EphemeralRoot(), "milksu-computer-use")
+	root := hostpath.ComputerUseRuntimeRoot()
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return "", err
 	}

--- a/internal/computercap/hyprland_session.go
+++ b/internal/computercap/hyprland_session.go
@@ -1,0 +1,344 @@
+package computercap
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/MilkSU-Official/milksu/internal/hostpath"
+)
+
+// hyprlandPointer is compositor-native virtual pointer input.
+// It must not be implemented with xinput, uinput, or /dev/input.
+type hyprlandPointer interface {
+	Click(x, y float64, width, height int) error
+	Scroll(direction string, amount int) error
+	Close() error
+}
+
+type hyprlandSession struct {
+	lookPath       func(string) (string, error)
+	run            func(ctx context.Context, name string, args ...string) ([]byte, error)
+	connectPointer func() (hyprlandPointer, error)
+	getenv         func(string) string
+
+	hyprctl string
+	grim    string
+	wtype   string
+	pointer hyprlandPointer
+	width   int
+	height  int
+	started bool
+}
+
+func newHyprlandSession() (PortalSession, error) {
+	return &hyprlandSession{
+		lookPath:       exec.LookPath,
+		run:            runHyprlandHostCommand,
+		connectPointer: connectWaylandVirtualPointer,
+		getenv:         os.Getenv,
+	}, nil
+}
+
+func (session *hyprlandSession) Start(ctx context.Context) error {
+	if session.started {
+		return nil
+	}
+	if err := linuxHyprlandToolsReady(session.lookPath); err != nil {
+		return err
+	}
+	hyprctl, err := session.lookPath("hyprctl")
+	if err != nil {
+		return fmt.Errorf("%s", linuxHyprlandToolsProblem([]string{"hyprctl"}))
+	}
+	grim, err := session.lookPath("grim")
+	if err != nil {
+		return fmt.Errorf("%s", linuxHyprlandToolsProblem([]string{"grim"}))
+	}
+	wtype, err := session.lookPath("wtype")
+	if err != nil {
+		return fmt.Errorf("%s", linuxHyprlandToolsProblem([]string{"wtype"}))
+	}
+	session.hyprctl = hyprctl
+	session.grim = grim
+	session.wtype = wtype
+	session.probeMonitorSize(ctx)
+	_ = session.notify(ctx, 1, 8000, "MilkSU Computer Use 已开始：截屏、点击和打字会作用于整块 Hyprland 桌面，不是单个窗口，也不是 GNOME Portal。停止后键鼠归你。")
+	pointer, err := session.connectPointer()
+	if err != nil {
+		return fmt.Errorf("无法创建 Hyprland 虚拟指针：%w", err)
+	}
+	session.pointer = pointer
+	session.started = true
+	return nil
+}
+
+func (session *hyprlandSession) Screenshot(ctx context.Context) ([]byte, int, int, error) {
+	if !session.started {
+		return nil, 0, 0, fmt.Errorf("Hyprland Computer Use 尚未开始")
+	}
+	path, err := hyprlandShotPath()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer os.Remove(path)
+	if _, err := session.run(ctx, session.grim, "-t", "png", path); err != nil {
+		return nil, 0, 0, fmt.Errorf("Hyprland 截屏失败：%w", err)
+	}
+	png, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("读取 Hyprland 截屏：%w", err)
+	}
+	width, height := pngSize(png)
+	if width <= 0 || height <= 0 {
+		return nil, 0, 0, fmt.Errorf("Hyprland 截屏为空")
+	}
+	session.width = width
+	session.height = height
+	return png, width, height, nil
+}
+
+func (session *hyprlandSession) Click(x, y float64) error {
+	if session.pointer == nil {
+		return fmt.Errorf("Hyprland 虚拟指针不可用")
+	}
+	width, height := session.extent()
+	if err := session.pointer.Click(x, y, width, height); err != nil {
+		return err
+	}
+	if session.hyprctl != "" {
+		_ = session.moveVisibleCursor(x, y)
+	}
+	return nil
+}
+
+func (session *hyprlandSession) Type(text string) error {
+	if strings.TrimSpace(text) == "" {
+		return fmt.Errorf("type_text requires text")
+	}
+	if session.wtype == "" {
+		return fmt.Errorf("wtype 不可用")
+	}
+	_, err := session.run(context.Background(), session.wtype, "--", text)
+	if err != nil {
+		return fmt.Errorf("Hyprland 打字失败：%w", err)
+	}
+	return nil
+}
+
+func (session *hyprlandSession) Key(name string, modifiers []string) error {
+	if session.wtype == "" {
+		return fmt.Errorf("wtype 不可用")
+	}
+	args := make([]string, 0, 2+len(modifiers)*2)
+	for _, modifier := range modifiers {
+		mapped := wtypeModifier(modifier)
+		if mapped == "" {
+			continue
+		}
+		args = append(args, "-M", mapped)
+	}
+	args = append(args, "-k", wtypeKey(name))
+	for i := len(modifiers) - 1; i >= 0; i-- {
+		mapped := wtypeModifier(modifiers[i])
+		if mapped == "" {
+			continue
+		}
+		args = append(args, "-m", mapped)
+	}
+	if _, err := session.run(context.Background(), session.wtype, args...); err != nil {
+		return fmt.Errorf("Hyprland 按键失败：%w", err)
+	}
+	return nil
+}
+
+func (session *hyprlandSession) Scroll(direction string, amount int) error {
+	if session.pointer == nil {
+		return fmt.Errorf("Hyprland 虚拟指针不可用")
+	}
+	return session.pointer.Scroll(direction, amount)
+}
+
+func (session *hyprlandSession) Close() error {
+	var closeErr error
+	if session.pointer != nil {
+		closeErr = session.pointer.Close()
+		session.pointer = nil
+	}
+	if session.started && session.hyprctl != "" {
+		_ = session.notify(context.Background(), 5, 4000, "MilkSU Computer Use 已停止，键鼠已交还。")
+	}
+	session.started = false
+	return closeErr
+}
+
+func (session *hyprlandSession) extent() (int, int) {
+	if session.width > 0 && session.height > 0 {
+		return session.width, session.height
+	}
+	return 1920, 1080
+}
+
+func (session *hyprlandSession) notify(ctx context.Context, icon, millis int, message string) error {
+	if session.hyprctl == "" {
+		return nil
+	}
+	_, err := session.run(
+		ctx,
+		session.hyprctl,
+		"notify",
+		fmt.Sprintf("%d", icon),
+		fmt.Sprintf("%d", millis),
+		"rgb(0891b2)",
+		message,
+	)
+	return err
+}
+
+func (session *hyprlandSession) moveVisibleCursor(x, y float64) error {
+	_, err := session.run(
+		context.Background(),
+		session.hyprctl,
+		"dispatch",
+		"movecursor",
+		fmt.Sprintf("%d", int(x+0.5)),
+		fmt.Sprintf("%d", int(y+0.5)),
+	)
+	return err
+}
+
+func (session *hyprlandSession) probeMonitorSize(ctx context.Context) {
+	if session.hyprctl == "" {
+		return
+	}
+	output, err := session.run(ctx, session.hyprctl, "-j", "monitors")
+	if err != nil {
+		return
+	}
+	width, height, ok := parseHyprlandMonitorExtent(output)
+	if !ok {
+		return
+	}
+	session.width = width
+	session.height = height
+}
+
+type hyprlandMonitorJSON struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+func parseHyprlandMonitorExtent(raw []byte) (int, int, bool) {
+	var monitors []hyprlandMonitorJSON
+	if err := json.Unmarshal(raw, &monitors); err != nil || len(monitors) == 0 {
+		return 0, 0, false
+	}
+	minX, minY := monitors[0].X, monitors[0].Y
+	maxX := monitors[0].X + monitors[0].Width
+	maxY := monitors[0].Y + monitors[0].Height
+	for _, monitor := range monitors[1:] {
+		if monitor.X < minX {
+			minX = monitor.X
+		}
+		if monitor.Y < minY {
+			minY = monitor.Y
+		}
+		if monitor.X+monitor.Width > maxX {
+			maxX = monitor.X + monitor.Width
+		}
+		if monitor.Y+monitor.Height > maxY {
+			maxY = monitor.Y + monitor.Height
+		}
+	}
+	width := maxX - minX
+	height := maxY - minY
+	if width <= 0 || height <= 0 {
+		return 0, 0, false
+	}
+	return width, height, true
+}
+
+func hyprlandShotPath() (string, error) {
+	root := filepath.Join(hostpath.EphemeralRoot(), "milksu-computer-use")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", err
+	}
+	var raw [8]byte
+	_, _ = rand.Read(raw[:])
+	return filepath.Join(root, "hypr-shot-"+hex.EncodeToString(raw[:])+".png"), nil
+}
+
+func runHyprlandHostCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if forbiddenHostTool(name) {
+		return nil, fmt.Errorf("Hyprland Computer Use 拒绝调用 %s", filepath.Base(name))
+	}
+	for _, arg := range args {
+		if forbiddenHostTool(arg) {
+			return nil, fmt.Errorf("Hyprland Computer Use 拒绝调用 %s", filepath.Base(arg))
+		}
+	}
+	command := exec.CommandContext(ctx, name, args...)
+	command.Env = os.Environ()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			return output, err
+		}
+		return output, fmt.Errorf("%w: %s", err, detail)
+	}
+	return output, nil
+}
+
+func wtypeKey(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "enter", "return":
+		return "Return"
+	case "tab":
+		return "Tab"
+	case "escape", "esc":
+		return "Escape"
+	case "backspace":
+		return "BackSpace"
+	case "space":
+		return "space"
+	case "up":
+		return "Up"
+	case "down":
+		return "Down"
+	case "left":
+		return "Left"
+	case "right":
+		return "Right"
+	case "delete":
+		return "Delete"
+	default:
+		if name == "" {
+			return "Return"
+		}
+		return name
+	}
+}
+
+func wtypeModifier(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "shift":
+		return "shift"
+	case "ctrl", "control":
+		return "ctrl"
+	case "alt", "option":
+		return "alt"
+	case "cmd", "meta", "super", "win":
+		return "win"
+	default:
+		return ""
+	}
+}

--- a/internal/computercap/hyprland_start.go
+++ b/internal/computercap/hyprland_start.go
@@ -1,0 +1,44 @@
+package computercap
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func (manager *Manager) startLinuxHyprland(
+	ctx context.Context,
+	conversationID string,
+	selection TargetSelection,
+) (Status, error) {
+	if !manager.linuxHyprland() {
+		status := manager.Status()
+		return status, fmt.Errorf("%s", status.Problem)
+	}
+	if err := manager.linuxHyprlandTools(); err != nil {
+		return manager.Status(), err
+	}
+	target := linuxHyprlandDesktopTarget()
+	if selection.PID != 0 && selection.WindowID != 0 &&
+		(selection.PID != target.PID || selection.WindowID != target.WindowID) {
+		return manager.Status(), fmt.Errorf("Hyprland Computer Use 锁定整块桌面，不是单个窗口，也不能改走 GNOME Portal")
+	}
+	host, err := manager.newHyprland()
+	if err != nil {
+		return manager.Status(), fmt.Errorf("open Hyprland Computer Use: %w", err)
+	}
+	timeout := manager.startTimeout
+	if timeout < 20*time.Second {
+		timeout = 20 * time.Second
+	}
+	return manager.attachLinuxHostSession(
+		ctx,
+		conversationID,
+		host,
+		target,
+		timeout,
+		func(err error) error {
+			return fmt.Errorf("Hyprland Computer Use 未能启动：%w", err)
+		},
+	)
+}

--- a/internal/computercap/hyprland_test.go
+++ b/internal/computercap/hyprland_test.go
@@ -323,8 +323,8 @@ func TestLinuxHyprlandSessionScreenshotUsesHostpath(t *testing.T) {
 	if grimPath == "" {
 		t.Fatal("grim was not invoked")
 	}
-	if !strings.HasPrefix(grimPath, hostpath.EphemeralRoot()) {
-		t.Fatalf("grim path %q is not under hostpath ephemeral root %q", grimPath, hostpath.EphemeralRoot())
+	if !strings.HasPrefix(grimPath, hostpath.ComputerUseRuntimeRoot()) {
+		t.Fatalf("grim path %q is not under ComputerUseRuntimeRoot %q", grimPath, hostpath.ComputerUseRuntimeRoot())
 	}
 	if strings.HasPrefix(grimPath, "/tmp/milksu-") || strings.Contains(grimPath, "/private/tmp/") {
 		t.Fatalf("grim path hardcodes tmp: %q", grimPath)

--- a/internal/computercap/hyprland_test.go
+++ b/internal/computercap/hyprland_test.go
@@ -387,6 +387,33 @@ func TestLinuxHyprlandStartServesClickAndType(t *testing.T) {
 	}
 }
 
+func TestLinuxHyprlandSessionCloseDestroysPointer(t *testing.T) {
+	pointer := &fakeHyprlandPointer{}
+	session := &hyprlandSession{
+		lookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			return nil, nil
+		},
+		connectPointer: func() (hyprlandPointer, error) { return pointer, nil },
+		getenv:         func(string) string { return "" },
+	}
+	if err := session.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if session.pointer == nil {
+		t.Fatal("start did not attach a pointer")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !pointer.closed {
+		t.Fatal("stop left the virtual pointer alive")
+	}
+	if session.pointer != nil || session.started {
+		t.Fatalf("session still holds injection state: %#v", session)
+	}
+}
+
 func TestLinuxHyprlandRejectsWindowScopeSelection(t *testing.T) {
 	manager := New(Options{
 		GOOS:               "linux",

--- a/internal/computercap/hyprland_test.go
+++ b/internal/computercap/hyprland_test.go
@@ -1,0 +1,475 @@
+package computercap
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MilkSU-Official/milksu/internal/hostpath"
+)
+
+type fakeHyprlandPointer struct {
+	clicks  [][2]float64
+	scrolls []string
+	closed  bool
+}
+
+func (pointer *fakeHyprlandPointer) Click(x, y float64, _, _ int) error {
+	pointer.clicks = append(pointer.clicks, [2]float64{x, y})
+	return nil
+}
+
+func (pointer *fakeHyprlandPointer) Scroll(direction string, _ int) error {
+	pointer.scrolls = append(pointer.scrolls, direction)
+	return nil
+}
+
+func (pointer *fakeHyprlandPointer) Close() error {
+	pointer.closed = true
+	return nil
+}
+
+func TestLinuxHyprlandAvailableWithOwnBackend(t *testing.T) {
+	host := &fakePortal{}
+	manager := New(Options{
+		GOOS:           "linux",
+		GrantDirectory: t.TempDir(),
+		LinuxPortal:    func() bool { return false },
+		LinuxHyprland:  func() bool { return true },
+		LinuxHyprlandTools: func() error {
+			return nil
+		},
+		NewHyprland: func() (PortalSession, error) { return host, nil },
+		LinuxEnv: func(key string) string {
+			if key == "HYPRLAND_INSTANCE_SIGNATURE" {
+				return "abc"
+			}
+			if key == "XDG_CURRENT_DESKTOP" {
+				return "Hyprland"
+			}
+			if key == "XDG_SESSION_TYPE" {
+				return "wayland"
+			}
+			return ""
+		},
+		PermissionProbe: func(bool) Permissions { return Permissions{} },
+		PermissionOpen:  func(PermissionKind) {},
+		SigningProbe:    func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	status := manager.Status()
+	if !status.Available {
+		t.Fatalf("Hyprland must be available: %#v", status)
+	}
+	if status.Signing.Signature != linuxHyprlandSignature {
+		t.Fatalf("signing = %#v", status.Signing)
+	}
+	if strings.Contains(status.Problem, "暂不可用") {
+		t.Fatalf("Hyprland is still forced-unavailable: %q", status.Problem)
+	}
+	targets, err := manager.Targets()
+	if err != nil || len(targets) != 1 || targets[0].BundleID != linuxHyprlandBundleID {
+		t.Fatalf("targets = %#v %v", targets, err)
+	}
+	if targets[0].PID == linuxPortalSyntheticPID {
+		t.Fatal("Hyprland target reused the GNOME portal PID")
+	}
+}
+
+func TestLinuxPortalPathUnchangedOnGNOME(t *testing.T) {
+	portal := &fakePortal{}
+	manager := New(Options{
+		GOOS:           "linux",
+		GrantDirectory: t.TempDir(),
+		LinuxPortal:    func() bool { return true },
+		LinuxHyprland:  func() bool { return false },
+		NewPortal:      func() (PortalSession, error) { return portal, nil },
+		LinuxEnv: func(key string) string {
+			if key == "XDG_CURRENT_DESKTOP" {
+				return "ubuntu:GNOME"
+			}
+			if key == "XDG_SESSION_TYPE" {
+				return "wayland"
+			}
+			return ""
+		},
+		PermissionProbe: func(bool) Permissions { return Permissions{} },
+		SigningProbe:    func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	status := manager.Status()
+	if !status.Available || status.Signing.Signature != linuxPortalSignature {
+		t.Fatalf("GNOME portal path changed: %#v", status)
+	}
+	targets, err := manager.Targets()
+	if err != nil || targets[0].BundleID != linuxPortalBundleID {
+		t.Fatalf("GNOME targets = %#v %v", targets, err)
+	}
+}
+
+func TestLinuxKDEAndXorgStayUnavailable(t *testing.T) {
+	cases := []struct {
+		name string
+		env  func(string) string
+	}{
+		{
+			name: "kde-wayland",
+			env: func(key string) string {
+				switch key {
+				case "XDG_CURRENT_DESKTOP":
+					return "KDE"
+				case "XDG_SESSION_TYPE":
+					return "wayland"
+				default:
+					return ""
+				}
+			},
+		},
+		{
+			name: "xorg",
+			env: func(key string) string {
+				switch key {
+				case "XDG_CURRENT_DESKTOP":
+					return "ubuntu:GNOME"
+				case "XDG_SESSION_TYPE":
+					return "x11"
+				default:
+					return ""
+				}
+			},
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			manager := New(Options{
+				GOOS:            "linux",
+				GrantDirectory:  t.TempDir(),
+				LinuxPortal:     func() bool { return false },
+				LinuxHyprland:   func() bool { return false },
+				LinuxEnv:        test.env,
+				PermissionProbe: func(bool) Permissions { return Permissions{} },
+				SigningProbe:    func() SigningStatus { return SigningStatus{} },
+			})
+			defer manager.Close()
+			status := manager.Status()
+			if status.Available || status.Phase != "unavailable" {
+				t.Fatalf("expected unavailable: %#v", status)
+			}
+			if strings.Contains(status.Problem, "暂不可用") && strings.Contains(status.Problem, "Hyprland") {
+				t.Fatalf("non-Hyprland desktop used Hyprland unavailable copy: %q", status.Problem)
+			}
+			if _, err := manager.Targets(); err == nil {
+				t.Fatal("targets must fail")
+			}
+		})
+	}
+}
+
+func TestLinuxHyprlandMissingToolsNamesPackages(t *testing.T) {
+	manager := New(Options{
+		GOOS:          "linux",
+		LinuxPortal:   func() bool { return false },
+		LinuxHyprland: func() bool { return true },
+		LinuxHyprlandTools: func() error {
+			return errors.New(linuxHyprlandToolsProblem([]string{"grim", "wtype"}))
+		},
+		LinuxEnv: func(key string) string {
+			if key == "HYPRLAND_INSTANCE_SIGNATURE" {
+				return "abc"
+			}
+			return ""
+		},
+		PermissionProbe: func(bool) Permissions { return Permissions{} },
+		SigningProbe:    func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	status := manager.Status()
+	if status.Available {
+		t.Fatalf("missing tools must not be available: %#v", status)
+	}
+	if status.Signing.Signature != linuxHyprlandSignature {
+		t.Fatalf("missing-tools status should still name the Hyprland backend: %#v", status)
+	}
+	if !strings.Contains(status.Problem, "grim") || !strings.Contains(status.Problem, "wtype") {
+		t.Fatalf("problem = %q", status.Problem)
+	}
+	if strings.Contains(status.Problem, "暂不可用") {
+		t.Fatalf("missing tools still uses the old unavailable copy: %q", status.Problem)
+	}
+	prepared, err := manager.Prepare(t.Context(), PrepareOptions{})
+	if err == nil || prepared.Ready {
+		t.Fatalf("prepare = %#v %v", prepared, err)
+	}
+	if !strings.Contains(prepared.NextStep, "pacman") || strings.Contains(prepared.NextStep, "暂不可用") {
+		t.Fatalf("nextStep = %q", prepared.NextStep)
+	}
+	if strings.Contains(strings.ToLower(prepared.NextStep+prepared.Problem), "xinput") == false {
+		t.Fatalf("prepare should mention that xinput is not used: %#v", prepared)
+	}
+}
+
+func TestLinuxHyprlandPrepareReady(t *testing.T) {
+	manager := New(Options{
+		GOOS:               "linux",
+		LinuxPortal:        func() bool { return false },
+		LinuxHyprland:      func() bool { return true },
+		LinuxHyprlandTools: func() error { return nil },
+		PermissionProbe:    func(bool) Permissions { return Permissions{} },
+		SigningProbe:       func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	prepared, err := manager.Prepare(t.Context(), PrepareOptions{})
+	if err != nil || !prepared.Ready || prepared.Source != "hyprland-compositor" {
+		t.Fatalf("prepare = %#v %v", prepared, err)
+	}
+	if strings.Contains(prepared.NextStep, "GNOME Portal") == false &&
+		strings.Contains(prepared.NextStep, "不是 GNOME Portal") == false {
+		t.Fatalf("prepare must say Hyprland is not Portal: %q", prepared.NextStep)
+	}
+}
+
+func TestLinuxHyprlandNeverCallsXinput(t *testing.T) {
+	var names []string
+	session := &hyprlandSession{
+		lookPath: func(name string) (string, error) {
+			names = append(names, name)
+			if forbiddenHostTool(name) {
+				t.Fatalf("lookPath requested forbidden tool %q", name)
+			}
+			return "/usr/bin/" + name, nil
+		},
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			names = append(names, name)
+			if forbiddenHostTool(name) {
+				t.Fatalf("run requested forbidden tool %q", name)
+			}
+			for _, arg := range args {
+				if forbiddenHostTool(arg) || strings.Contains(arg, "xinput") {
+					t.Fatalf("run args used forbidden tool %q", arg)
+				}
+			}
+			if strings.HasSuffix(name, "hyprctl") && len(args) >= 2 && args[0] == "-j" {
+				return []byte(`[{"x":0,"y":0,"width":1920,"height":1080,"focused":true}]`), nil
+			}
+			return nil, nil
+		},
+		connectPointer: func() (hyprlandPointer, error) {
+			return &fakeHyprlandPointer{}, nil
+		},
+		getenv: func(string) string { return "" },
+	}
+	if err := session.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Type("hi"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range names {
+		base := filepath.Base(name)
+		if forbiddenHostTool(base) || base == "xinput" {
+			t.Fatalf("Hyprland session touched %q", name)
+		}
+	}
+}
+
+func TestLinuxHyprlandSessionScreenshotUsesHostpath(t *testing.T) {
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	pointer := &fakeHyprlandPointer{}
+	var grimPath string
+	session := &hyprlandSession{
+		lookPath: func(name string) (string, error) { return "/bin/" + name, nil },
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if strings.HasSuffix(name, "grim") {
+				grimPath = args[len(args)-1]
+				png := []byte{
+					0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+					0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+					0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+					0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+					0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+					0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+					0x00, 0x00, 0x03, 0x00, 0x01, 0x3b, 0x6d, 0xa8,
+					0xdb, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+					0x44, 0xae, 0x42, 0x60, 0x82,
+				}
+				if err := os.WriteFile(grimPath, png, 0o600); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		},
+		connectPointer: func() (hyprlandPointer, error) { return pointer, nil },
+		getenv:         os.Getenv,
+	}
+	if err := session.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	png, width, height, err := session.Screenshot(t.Context())
+	if err != nil || width != 1 || height != 1 || len(png) == 0 {
+		t.Fatalf("screenshot = %d %d %v", width, height, err)
+	}
+	if grimPath == "" {
+		t.Fatal("grim was not invoked")
+	}
+	if !strings.HasPrefix(grimPath, hostpath.EphemeralRoot()) {
+		t.Fatalf("grim path %q is not under hostpath ephemeral root %q", grimPath, hostpath.EphemeralRoot())
+	}
+	if strings.HasPrefix(grimPath, "/tmp/milksu-") || strings.Contains(grimPath, "/private/tmp/") {
+		t.Fatalf("grim path hardcodes tmp: %q", grimPath)
+	}
+	if err := session.Click(12, 34); err != nil {
+		t.Fatal(err)
+	}
+	if len(pointer.clicks) != 1 || pointer.clicks[0] != [2]float64{12, 34} {
+		t.Fatalf("clicks = %#v", pointer.clicks)
+	}
+}
+
+func TestLinuxHyprlandStartServesClickAndType(t *testing.T) {
+	host := &fakePortal{}
+	manager := New(Options{
+		GOOS:               "linux",
+		GrantDirectory:     t.TempDir(),
+		LinuxPortal:        func() bool { return false },
+		LinuxHyprland:      func() bool { return true },
+		LinuxHyprlandTools: func() error { return nil },
+		NewHyprland:        func() (PortalSession, error) { return host, nil },
+		PermissionProbe:    func(bool) Permissions { return Permissions{} },
+		SigningProbe:       func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	started, err := manager.Start(t.Context(), "conv_linux_hyprland_1", TargetSelection{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started.Phase != "ready" || started.Signing.Signature != linuxHyprlandSignature || !host.started {
+		t.Fatalf("start = %#v started=%v", started, host.started)
+	}
+	descriptor, ok := manager.Descriptor("conv_linux_hyprland_1")
+	if !ok {
+		t.Fatal("missing descriptor")
+	}
+	conn, err := net.DialTimeout("unix", descriptor.SocketPath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte(`{"tool":"click","args":{"x":8,"y":9}}` + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	_ = conn.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reply portalReply
+	if err := json.Unmarshal(buf[:n], &reply); err != nil {
+		t.Fatal(err)
+	}
+	if reply.Error != "" || len(host.clicks) != 1 {
+		t.Fatalf("click = %#v host=%#v", reply, host)
+	}
+	stopped, err := manager.Stop("conv_linux_hyprland_1")
+	if err != nil || stopped.Enabled || !host.closed {
+		t.Fatalf("stop = %#v closed=%v err=%v", stopped, host.closed, err)
+	}
+}
+
+func TestLinuxHyprlandRejectsWindowScopeSelection(t *testing.T) {
+	manager := New(Options{
+		GOOS:               "linux",
+		GrantDirectory:     t.TempDir(),
+		LinuxPortal:        func() bool { return false },
+		LinuxHyprland:      func() bool { return true },
+		LinuxHyprlandTools: func() error { return nil },
+		NewHyprland:        func() (PortalSession, error) { return &fakePortal{}, nil },
+		PermissionProbe:    func(bool) Permissions { return Permissions{} },
+		SigningProbe:       func() SigningStatus { return SigningStatus{} },
+	})
+	defer manager.Close()
+	_, err := manager.Start(t.Context(), "conv_linux_hyprland_win", TargetSelection{PID: 99, WindowID: 7})
+	if err == nil || !strings.Contains(err.Error(), "不是单个窗口") {
+		t.Fatalf("window-scope error = %v", err)
+	}
+}
+
+func TestForbiddenHostToolRejectsXinput(t *testing.T) {
+	for _, name := range []string{"xinput", "/usr/bin/xinput", "ydotool", "libuinput-helper"} {
+		if !forbiddenHostTool(name) {
+			t.Fatalf("%q must be forbidden", name)
+		}
+	}
+	for _, name := range []string{"hyprctl", "grim", "wtype"} {
+		if forbiddenHostTool(name) {
+			t.Fatalf("%q must stay allowed", name)
+		}
+	}
+}
+
+func TestParseHyprlandMonitorExtent(t *testing.T) {
+	width, height, ok := parseHyprlandMonitorExtent([]byte(`[
+		{"x":0,"y":0,"width":1920,"height":1080},
+		{"x":1920,"y":0,"width":1280,"height":1024}
+	]`))
+	if !ok || width != 3200 || height != 1080 {
+		t.Fatalf("extent = %d %d ok=%v", width, height, ok)
+	}
+}
+
+func TestWaylandRequestEncoding(t *testing.T) {
+	payload := encodeGetRegistry(1, 2)
+	if len(payload) != 12 {
+		t.Fatalf("get_registry size = %d", len(payload))
+	}
+	if binary.LittleEndian.Uint32(payload[0:4]) != 1 {
+		t.Fatalf("object id = %d", binary.LittleEndian.Uint32(payload[0:4]))
+	}
+	word := binary.LittleEndian.Uint32(payload[4:8])
+	if word&0xffff != wlDisplayGetRegistry {
+		t.Fatalf("opcode = %d", word&0xffff)
+	}
+	if word>>16 != 12 {
+		t.Fatalf("size = %d", word>>16)
+	}
+	click := encodePointerButton(5, linuxButtonLeftHypr, 1)
+	objectID, opcode, body, err := readWaylandMessage(bytes.NewReader(click))
+	if err != nil || objectID != 5 || opcode != virtualPointerButton {
+		t.Fatalf("button message = %d %d %v", objectID, opcode, err)
+	}
+	if binary.LittleEndian.Uint32(body[4:8]) != linuxButtonLeftHypr {
+		t.Fatalf("button = %d", binary.LittleEndian.Uint32(body[4:8]))
+	}
+}
+
+func TestHyprlandWaylandSocketUsesRuntimeDir(t *testing.T) {
+	path, err := hyprlandWaylandSocket(func(key string) string {
+		if key == "XDG_RUNTIME_DIR" {
+			return "/run/user/1000"
+		}
+		if key == "WAYLAND_DISPLAY" {
+			return "wayland-2"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "/run/user/1000/wayland-2" {
+		t.Fatalf("socket = %q", path)
+	}
+	if strings.HasPrefix(path, "/tmp/") {
+		t.Fatalf("wayland socket used /tmp: %q", path)
+	}
+}

--- a/internal/computercap/hyprland_wayland.go
+++ b/internal/computercap/hyprland_wayland.go
@@ -1,0 +1,361 @@
+package computercap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	wlDisplayID              = 1
+	wlDisplayGetRegistry     = 1
+	wlDisplaySync            = 0
+	wlDisplayEventError      = 0
+	wlRegistryBind           = 0
+	wlRegistryEventGlobal    = 0
+	wlCallbackEventDone      = 0
+	virtualPointerMotionAbs  = 1
+	virtualPointerButton     = 2
+	virtualPointerAxis       = 3
+	virtualPointerFrame      = 4
+	virtualPointerAxisStop   = 6
+	virtualPointerAxisDisc   = 7
+	virtualPointerDestroy    = 8
+	virtualPointerManagerNew = 0
+	linuxButtonLeftHypr      = 272
+	waylandFixedOne          = 256
+)
+
+type waylandVirtualPointer struct {
+	mu      sync.Mutex
+	conn    net.Conn
+	pointer uint32
+	nextID  uint32
+	closed  bool
+}
+
+func connectWaylandVirtualPointer() (hyprlandPointer, error) {
+	return connectWaylandVirtualPointerEnv(os.Getenv)
+}
+
+func connectWaylandVirtualPointerEnv(getenv func(string) string) (hyprlandPointer, error) {
+	path, err := hyprlandWaylandSocket(getenv)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("连接 Wayland 显示 %s：%w", path, err)
+	}
+	pointer, err := bindVirtualPointer(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return pointer, nil
+}
+
+func bindVirtualPointer(conn net.Conn) (*waylandVirtualPointer, error) {
+	client := &waylandVirtualPointer{conn: conn, nextID: 2}
+	registryID := client.allocID()
+	if err := client.write(encodeGetRegistry(wlDisplayID, registryID)); err != nil {
+		return nil, err
+	}
+	callbackID := client.allocID()
+	if err := client.write(encodeSync(wlDisplayID, callbackID)); err != nil {
+		return nil, err
+	}
+	var managerName, managerVersion uint32
+	found := false
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		objectID, opcode, payload, err := readWaylandMessage(conn)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			return nil, err
+		}
+		if objectID == wlDisplayID && opcode == wlDisplayEventError {
+			return nil, waylandDisplayError(payload)
+		}
+		if objectID == registryID && opcode == wlRegistryEventGlobal {
+			name, iface, version, ok := parseRegistryGlobal(payload)
+			if ok && iface == "zwlr_virtual_pointer_manager_v1" {
+				managerName = name
+				managerVersion = version
+				found = true
+			}
+			continue
+		}
+		if objectID == callbackID && opcode == wlCallbackEventDone {
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("当前 Hyprland 没有 zwlr_virtual_pointer。无法合成点击，不会改用 xinput")
+	}
+	if managerVersion == 0 || managerVersion > 2 {
+		managerVersion = 2
+	}
+	managerID := client.allocID()
+	if err := client.write(encodeRegistryBind(registryID, managerName, "zwlr_virtual_pointer_manager_v1", managerVersion, managerID)); err != nil {
+		return nil, err
+	}
+	pointerID := client.allocID()
+	if err := client.write(encodeCreateVirtualPointer(managerID, pointerID)); err != nil {
+		return nil, err
+	}
+	client.pointer = pointerID
+	return client, nil
+}
+
+func (pointer *waylandVirtualPointer) Click(x, y float64, width, height int) error {
+	pointer.mu.Lock()
+	defer pointer.mu.Unlock()
+	if pointer.closed {
+		return fmt.Errorf("Hyprland 虚拟指针已关闭")
+	}
+	if width <= 0 {
+		width = 1920
+	}
+	if height <= 0 {
+		height = 1080
+	}
+	px := uint32(math.Max(0, math.Min(float64(width), x+0.5)))
+	py := uint32(math.Max(0, math.Min(float64(height), y+0.5)))
+	if err := pointer.write(encodePointerMotionAbsolute(pointer.pointer, px, py, uint32(width), uint32(height))); err != nil {
+		return err
+	}
+	if err := pointer.write(encodePointerButton(pointer.pointer, linuxButtonLeftHypr, 1)); err != nil {
+		return err
+	}
+	if err := pointer.write(encodePointerButton(pointer.pointer, linuxButtonLeftHypr, 0)); err != nil {
+		return err
+	}
+	return pointer.write(encodePointerFrame(pointer.pointer))
+}
+
+func (pointer *waylandVirtualPointer) Scroll(direction string, amount int) error {
+	pointer.mu.Lock()
+	defer pointer.mu.Unlock()
+	if pointer.closed {
+		return fmt.Errorf("Hyprland 虚拟指针已关闭")
+	}
+	if amount < 1 {
+		amount = 1
+	}
+	axis := uint32(0)
+	steps := int32(amount)
+	switch strings.ToLower(direction) {
+	case "up":
+		steps = -int32(amount)
+	case "down":
+		steps = int32(amount)
+	case "left":
+		axis = 1
+		steps = -int32(amount)
+	case "right":
+		axis = 1
+		steps = int32(amount)
+	}
+	value := int32(steps) * 10 * waylandFixedOne
+	if err := pointer.write(encodePointerAxisDiscrete(pointer.pointer, axis, value, steps)); err != nil {
+		return err
+	}
+	if err := pointer.write(encodePointerAxisStop(pointer.pointer, axis)); err != nil {
+		return err
+	}
+	return pointer.write(encodePointerFrame(pointer.pointer))
+}
+
+func (pointer *waylandVirtualPointer) Close() error {
+	pointer.mu.Lock()
+	defer pointer.mu.Unlock()
+	if pointer.closed {
+		return nil
+	}
+	pointer.closed = true
+	if pointer.pointer != 0 {
+		_ = pointer.write(encodePointerDestroy(pointer.pointer))
+	}
+	if pointer.conn != nil {
+		return pointer.conn.Close()
+	}
+	return nil
+}
+
+func (pointer *waylandVirtualPointer) allocID() uint32 {
+	id := pointer.nextID
+	pointer.nextID++
+	return id
+}
+
+func (pointer *waylandVirtualPointer) write(payload []byte) error {
+	_, err := pointer.conn.Write(payload)
+	return err
+}
+
+func encodeGetRegistry(displayID, registryID uint32) []byte {
+	return encodeWaylandRequest(displayID, wlDisplayGetRegistry, encodeUint32(nil, registryID))
+}
+
+func encodeSync(displayID, callbackID uint32) []byte {
+	return encodeWaylandRequest(displayID, wlDisplaySync, encodeUint32(nil, callbackID))
+}
+
+func encodeRegistryBind(registryID, name uint32, iface string, version, newID uint32) []byte {
+	payload := encodeUint32(nil, name)
+	payload = encodeWaylandString(payload, iface)
+	payload = encodeUint32(payload, version)
+	payload = encodeUint32(payload, newID)
+	return encodeWaylandRequest(registryID, wlRegistryBind, payload)
+}
+
+func encodeCreateVirtualPointer(managerID, pointerID uint32) []byte {
+	payload := encodeUint32(nil, 0) // null seat
+	payload = encodeUint32(payload, pointerID)
+	return encodeWaylandRequest(managerID, virtualPointerManagerNew, payload)
+}
+
+func encodePointerMotionAbsolute(pointerID, x, y, xExtent, yExtent uint32) []byte {
+	payload := encodeUint32(nil, 0) // time
+	payload = encodeUint32(payload, x)
+	payload = encodeUint32(payload, y)
+	payload = encodeUint32(payload, xExtent)
+	payload = encodeUint32(payload, yExtent)
+	return encodeWaylandRequest(pointerID, virtualPointerMotionAbs, payload)
+}
+
+func encodePointerButton(pointerID, button, state uint32) []byte {
+	payload := encodeUint32(nil, 0)
+	payload = encodeUint32(payload, button)
+	payload = encodeUint32(payload, state)
+	return encodeWaylandRequest(pointerID, virtualPointerButton, payload)
+}
+
+func encodePointerAxisDiscrete(pointerID, axis uint32, value int32, discrete int32) []byte {
+	payload := encodeUint32(nil, 0)
+	payload = encodeUint32(payload, axis)
+	payload = encodeInt32(payload, value)
+	payload = encodeInt32(payload, discrete)
+	return encodeWaylandRequest(pointerID, virtualPointerAxisDisc, payload)
+}
+
+func encodePointerAxisStop(pointerID, axis uint32) []byte {
+	payload := encodeUint32(nil, 0)
+	payload = encodeUint32(payload, axis)
+	return encodeWaylandRequest(pointerID, virtualPointerAxisStop, payload)
+}
+
+func encodePointerFrame(pointerID uint32) []byte {
+	return encodeWaylandRequest(pointerID, virtualPointerFrame, nil)
+}
+
+func encodePointerDestroy(pointerID uint32) []byte {
+	return encodeWaylandRequest(pointerID, virtualPointerDestroy, nil)
+}
+
+func encodeWaylandRequest(objectID uint32, opcode uint16, payload []byte) []byte {
+	size := uint32(8 + len(payload))
+	header := make([]byte, 8)
+	binary.LittleEndian.PutUint32(header[0:4], objectID)
+	binary.LittleEndian.PutUint32(header[4:8], (size<<16)|uint32(opcode))
+	return append(header, payload...)
+}
+
+func encodeUint32(buf []byte, value uint32) []byte {
+	var raw [4]byte
+	binary.LittleEndian.PutUint32(raw[:], value)
+	return append(buf, raw[:]...)
+}
+
+func encodeInt32(buf []byte, value int32) []byte {
+	return encodeUint32(buf, uint32(value))
+}
+
+func encodeWaylandString(buf []byte, value string) []byte {
+	size := uint32(len(value) + 1)
+	buf = encodeUint32(buf, size)
+	buf = append(buf, value...)
+	buf = append(buf, 0)
+	for len(buf)%4 != 0 {
+		buf = append(buf, 0)
+	}
+	return buf
+}
+
+func readWaylandMessage(r io.Reader) (objectID uint32, opcode uint16, payload []byte, err error) {
+	var header [8]byte
+	if _, err = io.ReadFull(r, header[:]); err != nil {
+		return 0, 0, nil, err
+	}
+	objectID = binary.LittleEndian.Uint32(header[0:4])
+	word := binary.LittleEndian.Uint32(header[4:8])
+	opcode = uint16(word & 0xffff)
+	size := word >> 16
+	if size < 8 {
+		return 0, 0, nil, fmt.Errorf("wayland message too small")
+	}
+	payload = make([]byte, size-8)
+	if len(payload) == 0 {
+		return objectID, opcode, payload, nil
+	}
+	if _, err = io.ReadFull(r, payload); err != nil {
+		return 0, 0, nil, err
+	}
+	return objectID, opcode, payload, nil
+}
+
+func parseRegistryGlobal(payload []byte) (name uint32, iface string, version uint32, ok bool) {
+	if len(payload) < 8 {
+		return 0, "", 0, false
+	}
+	name = binary.LittleEndian.Uint32(payload[0:4])
+	iface, rest, ok := decodeWaylandString(payload[4:])
+	if !ok || len(rest) < 4 {
+		return 0, "", 0, false
+	}
+	version = binary.LittleEndian.Uint32(rest[0:4])
+	return name, iface, version, true
+}
+
+func decodeWaylandString(payload []byte) (string, []byte, bool) {
+	if len(payload) < 4 {
+		return "", nil, false
+	}
+	size := binary.LittleEndian.Uint32(payload[0:4])
+	padded := (size + 3) &^ 3
+	if size == 0 || uint32(len(payload)) < 4+padded {
+		return "", nil, false
+	}
+	data := payload[4 : 4+size]
+	if data[len(data)-1] != 0 {
+		return "", nil, false
+	}
+	return string(data[:len(data)-1]), payload[4+padded:], true
+}
+
+func waylandDisplayError(payload []byte) error {
+	if len(payload) < 8 {
+		return fmt.Errorf("wayland display error")
+	}
+	objectID := binary.LittleEndian.Uint32(payload[0:4])
+	code := binary.LittleEndian.Uint32(payload[4:8])
+	message, _, _ := decodeWaylandString(payload[8:])
+	if message == "" {
+		return fmt.Errorf("wayland object %d error %d", objectID, code)
+	}
+	return fmt.Errorf("wayland object %d error %d: %s", objectID, code, message)
+}
+
+// Keep the unused axis opcode referenced so a later discrete-less
+// compositor path can switch without inventing a second protocol table.
+var _ = virtualPointerAxis

--- a/internal/computercap/hyprland_wayland.go
+++ b/internal/computercap/hyprland_wayland.go
@@ -185,9 +185,12 @@ func (pointer *waylandVirtualPointer) Close() error {
 	pointer.closed = true
 	if pointer.pointer != 0 {
 		_ = pointer.write(encodePointerDestroy(pointer.pointer))
+		pointer.pointer = 0
 	}
 	if pointer.conn != nil {
-		return pointer.conn.Close()
+		err := pointer.conn.Close()
+		pointer.conn = nil
+		return err
 	}
 	return nil
 }

--- a/internal/computercap/linux_host.go
+++ b/internal/computercap/linux_host.go
@@ -1,0 +1,99 @@
+package computercap
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func (manager *Manager) attachLinuxHostSession(
+	ctx context.Context,
+	conversationID string,
+	host PortalSession,
+	target Target,
+	timeout time.Duration,
+	startFail func(error) error,
+) (Status, error) {
+	if timeout <= 0 {
+		timeout = manager.startTimeout
+	}
+	hostCtx, cancel := context.WithTimeout(ctx, timeout)
+	if err := host.Start(hostCtx); err != nil {
+		cancel()
+		_ = host.Close()
+		if startFail != nil {
+			return manager.Status(), startFail(err)
+		}
+		return manager.Status(), err
+	}
+	sessionID, err := newSessionID()
+	if err != nil {
+		cancel()
+		_ = host.Close()
+		return manager.Status(), err
+	}
+	runtimeDirectoryRoot := runtimeRootForPlatform(manager.goos)
+	directory := filepath.Join(runtimeDirectoryRoot, sessionID)
+	if err := createRuntimeDirectory(runtimeDirectoryRoot, directory); err != nil {
+		cancel()
+		_ = host.Close()
+		return manager.Status(), err
+	}
+	socketPath := endpointForSession(manager.goos, directory, sessionID)
+	cleanupEndpoint(manager.goos, socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		cancel()
+		_ = host.Close()
+		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
+		return manager.Status(), fmt.Errorf("listen Linux Computer Use socket: %w", err)
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = listener.Close()
+		cancel()
+		_ = host.Close()
+		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
+		return manager.Status(), err
+	}
+	done := make(chan error, 1)
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	go func() {
+		done <- servePortalDriver(serveCtx, listener, host, target)
+	}()
+	active := &session{
+		conversationID: conversationID,
+		sessionID:      sessionID,
+		socketPath:     socketPath,
+		directory:      directory,
+		startedAt:      time.Now().UTC(),
+		done:           done,
+		phase:          "ready",
+		target:         target,
+		portal:         host,
+		portalCancel:   func() { serveCancel(); cancel() },
+		listener:       listener,
+	}
+	manager.mu.Lock()
+	if manager.active != nil {
+		manager.mu.Unlock()
+		active.portalCancel()
+		_ = listener.Close()
+		_ = host.Close()
+		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
+		return manager.Status(), fmt.Errorf("Computer Use is already attached to another visible Coding task")
+	}
+	manager.active = active
+	status := manager.statusLocked(Permissions{Accessibility: true, ScreenRecording: true})
+	manager.mu.Unlock()
+	if err := manager.grants.Save(conversationID, status.Target); err != nil {
+		_, _ = manager.stop(conversationID, false)
+		return manager.StatusForConversation(conversationID), err
+	}
+	status.Authorized = true
+	granted := status.Target
+	status.GrantedTarget = &granted
+	return status, nil
+}

--- a/internal/computercap/linux_test.go
+++ b/internal/computercap/linux_test.go
@@ -14,6 +14,8 @@ func TestLinuxComputerUseStaysUnavailableWithoutPortal(t *testing.T) {
 		GOOS:            "linux",
 		GrantDirectory:  t.TempDir(),
 		LinuxPortal:     func() bool { return false },
+		LinuxHyprland:   func() bool { return false },
+		LinuxEnv:        func(string) string { return "" },
 		PermissionProbe: func(bool) Permissions { return Permissions{} },
 		PermissionOpen:  func(PermissionKind) {},
 		SigningProbe:    func() SigningStatus { return SigningStatus{} },

--- a/internal/computercap/manager.go
+++ b/internal/computercap/manager.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	DriverVersion           = "0.14.2"
-	linuxComputerUseProblem = "Computer Use 在当前 Linux 桌面上不可用。GNOME Wayland 可走系统桌面共享授权；Hyprland 仍不可用。不会走 xinput 摘键鼠。"
+	linuxComputerUseProblem = "Computer Use 在当前 Linux 桌面上不可用。GNOME Wayland 可走系统桌面共享授权；Hyprland 可走合成器原生输入。Xorg 与其他桌面不可用。不会走 xinput 摘键鼠。"
 	defaultHostBundleID     = "com.milksu.app"
 	hostBundleIDEnv         = "MILKSU_DESKTOP_APP_ID"
 	hostBundleIDEnvAlt      = "CUA_DRIVER_HOST_BUNDLE_ID"
@@ -106,18 +106,21 @@ type Options struct {
 	TargetPID  int
 	// HostBundleID is the running host app's bundle identifier (stable or beta).
 	// When empty, Manager resolves it from SigningProbe / env / default.
-	HostBundleID    string
-	GOOS            string
-	PermissionProbe func(prompt bool) Permissions
-	PermissionOpen  func(PermissionKind)
-	SigningProbe    func() SigningStatus
-	TargetProvider  func() ([]Target, error)
-	CommandFactory  func(name string, args ...string) *exec.Cmd
-	StartTimeout    time.Duration
-	GrantDirectory  string
-	LinuxPortal     func() bool
-	NewPortal       func() (PortalSession, error)
-	LinuxEnv        func(string) string
+	HostBundleID       string
+	GOOS               string
+	PermissionProbe    func(prompt bool) Permissions
+	PermissionOpen     func(PermissionKind)
+	SigningProbe       func() SigningStatus
+	TargetProvider     func() ([]Target, error)
+	CommandFactory     func(name string, args ...string) *exec.Cmd
+	StartTimeout       time.Duration
+	GrantDirectory     string
+	LinuxPortal        func() bool
+	NewPortal          func() (PortalSession, error)
+	LinuxHyprland      func() bool
+	NewHyprland        func() (PortalSession, error)
+	LinuxHyprlandTools func() error
+	LinuxEnv           func(string) string
 }
 
 type session struct {
@@ -138,22 +141,25 @@ type session struct {
 }
 
 type Manager struct {
-	mu              sync.Mutex
-	binaryPath      string
-	targetPID       int
-	hostBundleID    string
-	goos            string
-	permissionProbe func(prompt bool) Permissions
-	permissionOpen  func(PermissionKind)
-	signingProbe    func() SigningStatus
-	targetProvider  func() ([]Target, error)
-	commandFactory  func(name string, args ...string) *exec.Cmd
-	startTimeout    time.Duration
-	grants          *grantStore
-	active          *session
-	linuxPortal     func() bool
-	newPortal       func() (PortalSession, error)
-	linuxEnv        func(string) string
+	mu                 sync.Mutex
+	binaryPath         string
+	targetPID          int
+	hostBundleID       string
+	goos               string
+	permissionProbe    func(prompt bool) Permissions
+	permissionOpen     func(PermissionKind)
+	signingProbe       func() SigningStatus
+	targetProvider     func() ([]Target, error)
+	commandFactory     func(name string, args ...string) *exec.Cmd
+	startTimeout       time.Duration
+	grants             *grantStore
+	active             *session
+	linuxPortal        func() bool
+	newPortal          func() (PortalSession, error)
+	linuxHyprland      func() bool
+	newHyprland        func() (PortalSession, error)
+	linuxHyprlandTools func() error
+	linuxEnv           func(string) string
 }
 
 func New(options Options) *Manager {
@@ -205,21 +211,36 @@ func New(options Options) *Manager {
 	if newPortal == nil {
 		newPortal = newXDGPortalSession
 	}
+	linuxHyprlandFn := options.LinuxHyprland
+	if linuxHyprlandFn == nil {
+		linuxHyprlandFn = func() bool { return linuxHyprland(linuxEnv) }
+	}
+	newHyprland := options.NewHyprland
+	if newHyprland == nil {
+		newHyprland = newHyprlandSession
+	}
+	hyprlandTools := options.LinuxHyprlandTools
+	if hyprlandTools == nil {
+		hyprlandTools = defaultHyprlandTools
+	}
 	return &Manager{
-		binaryPath:      strings.TrimSpace(options.BinaryPath),
-		targetPID:       targetPID,
-		hostBundleID:    hostBundleID,
-		goos:            goos,
-		permissionProbe: permissionProbe,
-		permissionOpen:  permissionOpen,
-		signingProbe:    signingProbe,
-		targetProvider:  targetProvider,
-		commandFactory:  commandFactory,
-		startTimeout:    startTimeout,
-		grants:          newGrantStore(options.GrantDirectory),
-		linuxPortal:     linuxPortal,
-		newPortal:       newPortal,
-		linuxEnv:        linuxEnv,
+		binaryPath:         strings.TrimSpace(options.BinaryPath),
+		targetPID:          targetPID,
+		hostBundleID:       hostBundleID,
+		goos:               goos,
+		permissionProbe:    permissionProbe,
+		permissionOpen:     permissionOpen,
+		signingProbe:       signingProbe,
+		targetProvider:     targetProvider,
+		commandFactory:     commandFactory,
+		startTimeout:       startTimeout,
+		grants:             newGrantStore(options.GrantDirectory),
+		linuxPortal:        linuxPortal,
+		newPortal:          newPortal,
+		linuxHyprland:      linuxHyprlandFn,
+		newHyprland:        newHyprland,
+		linuxHyprlandTools: hyprlandTools,
+		linuxEnv:           linuxEnv,
 	}
 }
 
@@ -334,10 +355,13 @@ func (manager *Manager) RequestPermission(kind PermissionKind) (Status, error) {
 
 func (manager *Manager) Targets() ([]Target, error) {
 	if manager.goos == "linux" {
-		if !manager.linuxPortal() {
-			return nil, fmt.Errorf("%s", linuxUnavailableProblem(manager.linuxEnv))
+		if manager.linuxPortal() {
+			return []Target{linuxPortalDesktopTarget()}, nil
 		}
-		return []Target{linuxPortalDesktopTarget()}, nil
+		if manager.linuxHyprland() {
+			return []Target{linuxHyprlandDesktopTarget()}, nil
+		}
+		return nil, fmt.Errorf("%s", linuxUnavailableProblem(manager.linuxEnv))
 	}
 	if manager.goos != "darwin" && manager.goos != "windows" {
 		return nil, fmt.Errorf("Computer Use is unavailable on this platform")
@@ -384,7 +408,14 @@ func (manager *Manager) Start(
 	}
 	if manager.goos == "linux" {
 		manager.mu.Unlock()
-		return manager.startLinuxPortal(ctx, conversationID, selection)
+		if manager.linuxPortal() {
+			return manager.startLinuxPortal(ctx, conversationID, selection)
+		}
+		if manager.linuxHyprland() {
+			return manager.startLinuxHyprland(ctx, conversationID, selection)
+		}
+		status := manager.Status()
+		return status, fmt.Errorf("%s", status.Problem)
 	}
 	if manager.goos != "darwin" && manager.goos != "windows" {
 		status := manager.statusLocked(manager.permissionProbe(false))
@@ -752,21 +783,37 @@ func (manager *Manager) statusLocked(permissions Permissions) Status {
 		Signing:       signing,
 	}
 	if manager.goos == "linux" {
-		if !manager.linuxPortal() {
+		if manager.linuxPortal() {
+			status.Available = true
+			status.Signing = linuxPortalSigning()
+			if !permissions.Accessibility && !permissions.ScreenRecording {
+				status.Permissions = Permissions{Accessibility: true, ScreenRecording: true}
+			}
+			if manager.active == nil {
+				return status
+			}
+		} else if manager.linuxHyprland() {
+			status.Signing = linuxHyprlandSigning()
+			if err := manager.linuxHyprlandTools(); err != nil {
+				status.Available = false
+				status.Phase = "unavailable"
+				status.Problem = err.Error()
+				return status
+			}
+			status.Available = true
+			if !permissions.Accessibility && !permissions.ScreenRecording {
+				status.Permissions = Permissions{Accessibility: true, ScreenRecording: true}
+			}
+			if manager.active == nil {
+				return status
+			}
+		} else {
 			status.Available = false
 			status.Phase = "unavailable"
 			status.Problem = linuxUnavailableProblem(manager.linuxEnv)
 			if status.Problem == "" {
 				status.Problem = linuxComputerUseProblem
 			}
-			return status
-		}
-		status.Available = true
-		status.Signing = linuxPortalSigning()
-		if !permissions.Accessibility && !permissions.ScreenRecording {
-			status.Permissions = Permissions{Accessibility: true, ScreenRecording: true}
-		}
-		if manager.active == nil {
 			return status
 		}
 	} else if manager.goos != "darwin" && manager.goos != "windows" {

--- a/internal/computercap/portal.go
+++ b/internal/computercap/portal.go
@@ -32,6 +32,9 @@ func linuxGnomeWayland(getenv func(string) string) bool {
 	if getenv == nil {
 		getenv = os.Getenv
 	}
+	if linuxHyprland(getenv) {
+		return false
+	}
 	session := strings.ToLower(strings.TrimSpace(getenv("XDG_SESSION_TYPE")))
 	wayland := session == "wayland" || strings.TrimSpace(getenv("WAYLAND_DISPLAY")) != ""
 	if !wayland {
@@ -72,7 +75,7 @@ func linuxPortalSigning() SigningStatus {
 
 func linuxUnavailableProblem(getenv func(string) string) string {
 	if linuxHyprland(getenv) {
-		return "Computer Use 在 Hyprland 上暂不可用。GNOME 可用系统桌面共享授权；不会走 xinput 摘键鼠。"
+		return linuxHyprlandToolsProblem(nil)
 	}
 	if linuxGnomeWayland(getenv) {
 		return ""

--- a/internal/computercap/portal_start.go
+++ b/internal/computercap/portal_start.go
@@ -3,9 +3,6 @@ package computercap
 import (
 	"context"
 	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -31,77 +28,14 @@ func (manager *Manager) startLinuxPortal(
 	if timeout < 90*time.Second {
 		timeout = 90 * time.Second
 	}
-	portalCtx, cancel := context.WithTimeout(ctx, timeout)
-	if err := portal.Start(portalCtx); err != nil {
-		cancel()
-		_ = portal.Close()
-		return manager.Status(), fmt.Errorf("GNOME 桌面共享未授权或已取消：%w", err)
-	}
-	sessionID, err := newSessionID()
-	if err != nil {
-		cancel()
-		_ = portal.Close()
-		return manager.Status(), err
-	}
-	runtimeDirectoryRoot := runtimeRootForPlatform(manager.goos)
-	directory := filepath.Join(runtimeDirectoryRoot, sessionID)
-	if err := createRuntimeDirectory(runtimeDirectoryRoot, directory); err != nil {
-		cancel()
-		_ = portal.Close()
-		return manager.Status(), err
-	}
-	socketPath := endpointForSession(manager.goos, directory, sessionID)
-	cleanupEndpoint(manager.goos, socketPath)
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		cancel()
-		_ = portal.Close()
-		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
-		return manager.Status(), fmt.Errorf("listen portal Computer Use socket: %w", err)
-	}
-	if err := os.Chmod(socketPath, 0o600); err != nil {
-		_ = listener.Close()
-		cancel()
-		_ = portal.Close()
-		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
-		return manager.Status(), err
-	}
-	done := make(chan error, 1)
-	serveCtx, serveCancel := context.WithCancel(context.Background())
-	go func() {
-		done <- servePortalDriver(serveCtx, listener, portal, target)
-	}()
-	active := &session{
-		conversationID: conversationID,
-		sessionID:      sessionID,
-		socketPath:     socketPath,
-		directory:      directory,
-		startedAt:      time.Now().UTC(),
-		done:           done,
-		phase:          "ready",
-		target:         target,
-		portal:         portal,
-		portalCancel:   func() { serveCancel(); cancel() },
-		listener:       listener,
-	}
-	manager.mu.Lock()
-	if manager.active != nil {
-		manager.mu.Unlock()
-		active.portalCancel()
-		_ = listener.Close()
-		_ = portal.Close()
-		_ = cleanupRuntimeDirectory(runtimeDirectoryRoot, directory)
-		return manager.Status(), fmt.Errorf("Computer Use is already attached to another visible Coding task")
-	}
-	manager.active = active
-	status := manager.statusLocked(Permissions{Accessibility: true, ScreenRecording: true})
-	manager.mu.Unlock()
-	if err := manager.grants.Save(conversationID, status.Target); err != nil {
-		_, _ = manager.stop(conversationID, false)
-		return manager.StatusForConversation(conversationID), err
-	}
-	status.Authorized = true
-	granted := status.Target
-	status.GrantedTarget = &granted
-	return status, nil
+	return manager.attachLinuxHostSession(
+		ctx,
+		conversationID,
+		portal,
+		target,
+		timeout,
+		func(err error) error {
+			return fmt.Errorf("GNOME 桌面共享未授权或已取消：%w", err)
+		},
+	)
 }

--- a/internal/computercap/portal_test.go
+++ b/internal/computercap/portal_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net"
 	"os"
-	"strings"
 	"testing"
 	"time"
 )
@@ -53,17 +52,24 @@ func (portal *fakePortal) Scroll(direction string, amount int) error {
 }
 func (portal *fakePortal) Close() error { portal.closed = true; return nil }
 
-func TestLinuxPortalUnavailableOffGNOME(t *testing.T) {
+func TestLinuxPortalDoesNotClaimHyprland(t *testing.T) {
 	manager := New(Options{
 		GOOS:           "linux",
 		GrantDirectory: t.TempDir(),
 		LinuxPortal:    func() bool { return false },
+		LinuxHyprland:  func() bool { return true },
+		LinuxHyprlandTools: func() error {
+			return nil
+		},
 		LinuxEnv: func(key string) string {
 			if key == "XDG_CURRENT_DESKTOP" {
 				return "Hyprland"
 			}
 			if key == "XDG_SESSION_TYPE" {
 				return "wayland"
+			}
+			if key == "HYPRLAND_INSTANCE_SIGNATURE" {
+				return "abc"
 			}
 			return ""
 		},
@@ -73,11 +79,14 @@ func TestLinuxPortalUnavailableOffGNOME(t *testing.T) {
 	})
 	defer manager.Close()
 	status := manager.Status()
-	if status.Available {
-		t.Fatalf("Hyprland must stay unavailable: %#v", status)
+	if !status.Available {
+		t.Fatalf("Hyprland must use its own backend, not stay unavailable: %#v", status)
 	}
-	if !strings.Contains(status.Problem, "Hyprland") {
-		t.Fatalf("problem = %q", status.Problem)
+	if status.Signing.Signature == linuxPortalSignature {
+		t.Fatalf("Hyprland must not reuse the GNOME portal signature: %#v", status)
+	}
+	if status.Signing.Signature != linuxHyprlandSignature {
+		t.Fatalf("signing = %#v", status.Signing)
 	}
 }
 

--- a/internal/computercap/prepare.go
+++ b/internal/computercap/prepare.go
@@ -277,6 +277,21 @@ func (manager *Manager) Prepare(ctx context.Context, options PrepareOptions) (Pr
 				NextStep: "启动 Computer Use 时，GNOME 会弹出桌面共享授权。",
 			}, nil
 		}
+		if manager.linuxHyprland() {
+			if err := manager.linuxHyprlandTools(); err != nil {
+				return PrepareResult{
+					Version:  DriverVersion,
+					Problem:  err.Error(),
+					NextStep: linuxHyprlandToolsNextStep,
+				}, err
+			}
+			return PrepareResult{
+				Ready:    true,
+				Source:   "hyprland-compositor",
+				Version:  DriverVersion,
+				NextStep: linuxHyprlandPrepareNextStep,
+			}, nil
+		}
 		problem := linuxUnavailableProblem(manager.linuxEnv)
 		if problem == "" {
 			problem = linuxComputerUseProblem
@@ -284,14 +299,14 @@ func (manager *Manager) Prepare(ctx context.Context, options PrepareOptions) (Pr
 		return PrepareResult{
 			Version:  DriverVersion,
 			Problem:  problem,
-			NextStep: "在 GNOME Wayland 上使用系统桌面共享；Hyprland 仍不可用。",
+			NextStep: "在 GNOME Wayland 或 Hyprland 上使用 Computer Use。Xorg 与其他桌面仍不可用。",
 		}, fmt.Errorf("%s", problem)
 	}
 	if manager.goos != "darwin" && manager.goos != "windows" {
 		return PrepareResult{
 			Version:  DriverVersion,
 			Problem:  linuxComputerUseProblem,
-			NextStep: "在 macOS、Windows 或 GNOME Wayland 上使用 Computer Use。",
+			NextStep: "在 macOS、Windows、GNOME Wayland 或 Hyprland 上使用 Computer Use。",
 		}, fmt.Errorf("%s", linuxComputerUseProblem)
 	}
 	manager.mu.Lock()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
让 Hyprland 上的 Computer Use 能截屏、按坐标点、打字。GNOME 那条系统桌面共享不要动。Xorg 仍然不可用。不用 xinput 摘键鼠。

这是 MilkSU 自己写的一条路（hyprctl、grim、wtype、虚拟指针），不经过 CUA。正式包 26.905.2 里 Hyprland 仍然不可用。真机还没在 Omarchy 上点过。

注意：你们现在打包的 CUA 是 0.14.2，那一版没有可用的 Hyprland。CUA 上游最新驱动已经到 0.27，里面开始有 Hyprland，但是实验、默认关，官方插件还要按本机 Hyprland 版本自己编，默认还不注入输入。合这篇之前先想清楚：继续自己做，还是改跟 CUA。
<!-- CURSOR_AGENT_PR_BODY_END -->