### PR TITLE
Windows CUA 源码钉按 LF 校验 Cargo.lock

### DIFF
--- a/docs/developer/current-objectives.md
+++ b/docs/developer/current-objectives.md
@@ -177,7 +177,7 @@
 - 计划 / 变更上拉框不再跟收缩后的胶囊同宽；展开后最小 18rem，步骤文案不再只剩两个字。
 - 下拉框、菜单、Dialog、Sheet 和对话小窗改用实底 `--surface-overlay` / `--popover`，不再套 68–74% 透明加 `backdrop-filter`。Windows 上 blur 经常不生效，字会看穿。Composer 岛仍可保留轻模糊。
 - 稳定 `milksu.plugin/v1` 插件候选已进入未发版 HEAD：Go 控制面管理确定性 Ed25519 签名包、发布者信任、升级/回滚/卸载与事务存储；公共 Runtime 为受限 Lua 和预编译 TypeScript，第三方工具只读，外部 MCP 逐插件开启。官方皮肤提供内容壁纸、列表、按钮、工作区顶部栏、下拉表面和 Composer 六个独立图片/纯色槽位，默认 `inherit` 保持核心原色并同步日夜遮罩。该能力尚未进入正式发行包。
-- Computer Use 驱动从 `cua-driver 0.14.2` 升到上游 `0.27.0`。macOS 继续用官方 universal 包；Windows 仍从同一 commit 源码编，并去掉 MilkSU 路径补丁（上游已有 `canonical_process_executable`）。Linux / Hyprland 仍不接 CUA。关 #56。
+- Computer Use 驱动从 `cua-driver 0.14.2` 升到上游 `0.27.0`。macOS 继续用官方 universal 包；Windows 仍从同一 commit 源码编，并去掉 MilkSU 路径补丁（上游已有 `canonical_process_executable`）。Linux / Hyprland 仍不接 CUA。关 #56。Windows 源码钉的 `Cargo.lock` 按 LF 归一化校验，避免上游 `* text=auto` 在 CI 上把锁文件改成 CRLF 后对不上。
 - 设置 → 模型在默认模型下增加 `subagent`：四个工作区派出的子 Agent 用这条覆盖，空则跟随当前对话正在用的主模型。覆盖不在可调用目录时清空。思考档位用该模型自己的默认档，只在子进程 `--model` 上改，不另造 harness。
 - 设置 → Skills 增加默认关闭的 `ghidra-rpc` / `jadx`。不选手动安装目录；行上只显示本机有没有找到。Ghidra 可用「准备」把固定版 CLI 装进配置目录。JADX 不包装，模型直接调本机 `jadx`。
 - 模型服务预置可编辑、可删除的 DeepSeek（`https://api.deepseek.com`，`deepseek-flash` / `deepseek-v4-pro`）。删掉并保存后不再自动出现。

--- a/scripts/build-windows-cua-driver.mjs
+++ b/scripts/build-windows-cua-driver.mjs
@@ -31,6 +31,8 @@ const windowsPlatformSourceRelativePath = join(
   'browser_platform.rs',
 )
 const licenseRelativePath = 'LICENSE.md'
+// Upstream * text=auto checks out CRLF on Windows. Hash after LF normalization
+// so the pin matches the git blob, not the working-tree line endings.
 const expectedCargoLockSha256 = '1200667c238ea4b425e7ab0b1e3bfa1c49b93158ae90bd52a15d5e78c2871678'
 const expectedWindowsPlatformSourceSha256 = '509e8467489b4201c947779dced4af267bdd68bd1a588a6d249404ef948fc53f'
 const buildRecipe = 'cua-driver-windows-pinned-source-v2'
@@ -215,7 +217,10 @@ async function verifySource(sourceRoot, gitEnvironment) {
       { env: gitEnvironment },
     )
     if (origin.trim() !== sourceRepository) return false
-    if (await sha256(join(sourceRoot, cargoLockRelativePath)) !== expectedCargoLockSha256) {
+    if (
+      await normalizedTextSha256(join(sourceRoot, cargoLockRelativePath))
+      !== expectedCargoLockSha256
+    ) {
       return false
     }
     if (
@@ -247,6 +252,9 @@ async function prepareSource(paths) {
   await run('git', ['-C', paths.source, 'config', 'core.autocrlf', 'false'], {
     env: gitEnvironment,
   })
+  await run('git', ['-C', paths.source, 'config', 'core.eol', 'lf'], {
+    env: gitEnvironment,
+  })
   await run('git', ['-C', paths.source, 'config', 'core.safecrlf', 'true'], {
     env: gitEnvironment,
   })
@@ -267,14 +275,19 @@ async function prepareSource(paths) {
   await run('git', ['-C', paths.source, 'checkout', '--quiet', '--detach', 'FETCH_HEAD'], {
     env: gitEnvironment,
   })
-  if (await sha256(join(paths.source, cargoLockRelativePath)) !== expectedCargoLockSha256) {
-    throw new Error('pinned Cua Cargo.lock checksum mismatch')
+  const cargoLockSha256 = await normalizedTextSha256(join(paths.source, cargoLockRelativePath))
+  if (cargoLockSha256 !== expectedCargoLockSha256) {
+    throw new Error(
+      `pinned Cua Cargo.lock checksum mismatch: expected ${expectedCargoLockSha256}, got ${cargoLockSha256}`,
+    )
   }
-  if (
-    await normalizedTextSha256(join(paths.source, windowsPlatformSourceRelativePath))
-    !== expectedWindowsPlatformSourceSha256
-  ) {
-    throw new Error('pinned Cua Windows platform source checksum mismatch')
+  const windowsPlatformSourceSha256 = await normalizedTextSha256(
+    join(paths.source, windowsPlatformSourceRelativePath),
+  )
+  if (windowsPlatformSourceSha256 !== expectedWindowsPlatformSourceSha256) {
+    throw new Error(
+      `pinned Cua Windows platform source checksum mismatch: expected ${expectedWindowsPlatformSourceSha256}, got ${windowsPlatformSourceSha256}`,
+    )
   }
   if (!await verifySource(paths.source, gitEnvironment)) {
     throw new Error('pinned Cua source failed provenance verification')

--- a/third_party/cua-driver/README.md
+++ b/third_party/cua-driver/README.md
@@ -17,8 +17,9 @@ target-manifest comparison (`canonical_process_executable`). The older MilkSU
 - License: upstream root `LICENSE.md` (MIT)
 - Rust: `1.97.1`
 - Target: `x86_64-pc-windows-msvc`
-- Upstream `Cargo.lock` SHA-256: `1200667c238ea4b425e7ab0b1e3bfa1c49b93158ae90bd52a15d5e78c2871678`
+- Upstream `Cargo.lock` SHA-256 after LF normalization: `1200667c238ea4b425e7ab0b1e3bfa1c49b93158ae90bd52a15d5e78c2871678`
 - `libs/cua-driver/rust/crates/platform-windows/src/browser_platform.rs` SHA-256 after LF normalization: `509e8467489b4201c947779dced4af267bdd68bd1a588a6d249404ef948fc53f`
+- Upstream `.gitattributes` has `* text=auto`. Windows checkout must not hash raw working-tree bytes, or the lockfile pin follows CRLF and fails CI.
 
 ## Compatibility boundary
 


### PR DESCRIPTION
## Summary
- #62 把 `cua-driver` 升到 0.27.0 后，Windows startup 在钉死的 `Cargo.lock` 校验处挂掉。
- 上游 `.gitattributes` 有 `* text=auto`，Windows 检出把锁文件变成 CRLF。`0.14.2` 钉的恰好是 CRLF 哈希；`0.27.0` 按 LF 钉，对不上。
- 锁文件改成和平台源码一样按 LF 归一化再哈希，检出时强制 `core.eol=lf`。驱动源和 commit 没改。

## Test plan
- [x] 对上游 `082de434` 的 `Cargo.lock`：LF 哈希等于钉值，CRLF 不等于
- [ ] Windows startup：`node scripts/build-windows-cua-driver.mjs verify` 能过 checksum（完整编驱动仍走 CI）


Made with [Cursor](https://cursor.com)