### PR TITLE
fix(coding): Pi writer 不再因 DSH smoke 的绝对 symlink 启动失败

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,3 @@
-node_modules/
-app/node_modules/
-build/sidecar-cache/
+/node_modules/
+/app/node_modules/
+/build/sidecar-cache/

--- a/internal/codingcollab/manager.go
+++ b/internal/codingcollab/manager.go
@@ -820,6 +820,23 @@ func (m *Manager) discoverWorktreeIncludes(
 	); err != nil {
 		return nil, errors.New(".worktreeinclude must be tracked by Git")
 	}
+	content, err := os.ReadFile(includeFile)
+	if err != nil {
+		return nil, fmt.Errorf("read .worktreeinclude: %w", err)
+	}
+	excludeFile, err := os.CreateTemp("", "milksu-worktreeinclude-*.txt")
+	if err != nil {
+		return nil, fmt.Errorf("create .worktreeinclude exclude file: %w", err)
+	}
+	excludePath := excludeFile.Name()
+	defer os.Remove(excludePath)
+	if _, err := excludeFile.WriteString(rewriteWorktreeIncludePatterns(string(content))); err != nil {
+		excludeFile.Close()
+		return nil, fmt.Errorf("write .worktreeinclude exclude file: %w", err)
+	}
+	if err := excludeFile.Close(); err != nil {
+		return nil, fmt.Errorf("close .worktreeinclude exclude file: %w", err)
+	}
 	output, err := m.git(
 		ctx,
 		repository,
@@ -827,7 +844,7 @@ func (m *Manager) discoverWorktreeIncludes(
 		"--others",
 		"--ignored",
 		"--directory",
-		"--exclude-from=.worktreeinclude",
+		"--exclude-from="+excludePath,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve .worktreeinclude paths: %w", err)
@@ -983,6 +1000,37 @@ func (m *Manager) gitPathIgnored(
 		path,
 	)
 	return command.Run() == nil
+}
+
+func rewriteWorktreeIncludePatterns(content string) string {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for index, line := range lines {
+		lines[index] = normalizeWorktreeIncludePattern(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func normalizeWorktreeIncludePattern(pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" || strings.HasPrefix(pattern, "#") {
+		return pattern
+	}
+	negated := false
+	if strings.HasPrefix(pattern, "!") {
+		negated = true
+		pattern = strings.TrimSpace(strings.TrimPrefix(pattern, "!"))
+	}
+	pattern = filepath.ToSlash(pattern)
+	if !strings.HasPrefix(pattern, "/") {
+		trimmed := strings.TrimSuffix(pattern, "/")
+		if !strings.Contains(trimmed, "/") {
+			pattern = "/" + pattern
+		}
+	}
+	if negated {
+		return "!" + pattern
+	}
+	return pattern
 }
 
 func validWorktreeIncludePath(value string) bool {

--- a/internal/codingcollab/manager_test.go
+++ b/internal/codingcollab/manager_test.go
@@ -284,6 +284,76 @@ func TestManagerSafelyFinishesWorktreeContainingSubmodule(t *testing.T) {
 	}
 }
 
+func TestManagerDoesNotCopyNestedNodeModulesMatchedByUnanchoredInclude(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repository := newRepository(t)
+	rootModules := filepath.Join(repository, "node_modules", "vitepress")
+	if err := os.MkdirAll(rootModules, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootModules, "package.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repository, "build", "sidecar-smoke", "dsh-home", "profiles", "node_modules", "@agentclientprotocol")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(
+		filepath.Join(string(filepath.Separator), "outside-acp-sdk"),
+		filepath.Join(nested, "sdk"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, ".gitignore"), []byte("node_modules/\nbuild/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, ".worktreeinclude"), []byte("node_modules/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repository, "add", ".gitignore", ".worktreeinclude")
+	git(t, repository, "commit", "-m", "configure nested ignored modules")
+
+	manager, err := New(filepath.Join(t.TempDir(), "collaboration"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := manager.Prepare(ctx, "nested-modules", repository, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writerRoot := filepath.Join(status.Worktrees[0].Path, "node_modules", "vitepress", "package.json")
+	if _, err := os.Lstat(writerRoot); err != nil {
+		t.Fatalf("root node_modules was not copied: %v", err)
+	}
+	escaped := filepath.Join(
+		status.Worktrees[0].Path,
+		"build",
+		"sidecar-smoke",
+		"dsh-home",
+		"profiles",
+		"node_modules",
+		"@agentclientprotocol",
+		"sdk",
+	)
+	if _, err := os.Lstat(escaped); !os.IsNotExist(err) {
+		t.Fatalf("nested smoke node_modules leaked into the writer: %v", err)
+	}
+}
+
+func TestNormalizeWorktreeIncludePatternRootsUnanchoredNames(t *testing.T) {
+	t.Parallel()
+	if got := normalizeWorktreeIncludePattern("node_modules/"); got != "/node_modules/" {
+		t.Fatalf("unanchored directory = %q", got)
+	}
+	if got := normalizeWorktreeIncludePattern("app/node_modules/"); got != "app/node_modules/" {
+		t.Fatalf("path pattern = %q", got)
+	}
+	if got := normalizeWorktreeIncludePattern("/node_modules/"); got != "/node_modules/" {
+		t.Fatalf("already rooted = %q", got)
+	}
+}
+
 func TestManagerRejectsWorktreeIncludeSymlinkEscapingRepository(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## 现象

在 Pi 会话里准备 Agent-managed Coding worktree 失败：

```text
.worktreeinclude contains an absolute symlink:
.../build/sidecar-smoke/darwin-arm64/dsh-home/profiles/node_modules/@agentclientprotocol/sdk
```

这是 Pi 的 writer 物化路径，不是 DSH 会话。核心 Coding 循环被 sidecar smoke 产物破坏。

## 原因

`.worktreeinclude` 里的 `node_modules/` 按 gitignore 语义匹配**任意一层**同名目录。`git ls-files --exclude-from=.worktreeinclude` 因此把

- 仓库根 `node_modules/`（该拷）
- `build/sidecar-smoke/.../dsh-home/profiles/node_modules/`（DSH smoke 留下的绝对 symlink，不该拷）

都选进 writer。`validateIncludedSymlinks` 看到绝对链接后整次 Prepare 失败。

## 修复

无路径分隔的 include 规则锚到仓库根：`node_modules/` → `/node_modules/`。`app/node_modules/` 这种已带路径的规则不变。本仓库 `.worktreeinclude` 同步写成根路径。

回归：根 `node_modules/` 仍会拷进 writer；嵌套 smoke `node_modules` 里的绝对 symlink 不再让 Prepare 失败。

```text
go test ./internal/codingcollab
```