### PR TITLE
fix(ui): 已发送图片可缩略预览并放大关闭

### DIFF
--- a/app/src/components-vue/ChatMessageItem.test.ts
+++ b/app/src/components-vue/ChatMessageItem.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { createApp, nextTick, type App } from 'vue'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import ChatMessageItem from './ChatMessageItem.vue'
 import type { Message } from '@/types'
 
@@ -10,6 +10,7 @@ const mountedApps: App[] = []
 afterEach(() => {
   for (const app of mountedApps.splice(0)) app.unmount()
   document.body.innerHTML = ''
+  Reflect.deleteProperty(window, 'milksu')
 })
 
 async function mountMessage(
@@ -379,6 +380,69 @@ describe('ChatMessageItem', () => {
     branch?.click()
     await nextTick()
     expect(assistant.branched()).toBe('')
+  })
+
+  it('shows a sent image thumbnail and opens a closable preview', async () => {
+    const attachment = {
+      id: 'a'.repeat(64),
+      name: 'image.png',
+      mediaType: 'image/png',
+      size: 37888,
+      sha256: 'b'.repeat(64),
+    }
+    const dataUrl = 'data:image/png;base64,aW1hZ2U='
+    const invoke = vi.fn(async (method: string) => {
+      if (method === 'PreviewCodingAttachment') {
+        return {
+          name: attachment.name,
+          mediaType: attachment.mediaType,
+          size: attachment.size,
+          kind: 'image',
+          dataUrl,
+        }
+      }
+      throw new Error(method)
+    })
+    Object.defineProperty(window, 'milksu', {
+      configurable: true,
+      value: { invoke },
+    })
+    const dialogProto = HTMLDialogElement.prototype as HTMLDialogElement & {
+      showModal?: () => void
+      close?: () => void
+    }
+    const previousShow = dialogProto.showModal
+    const previousClose = dialogProto.close
+    dialogProto.showModal = function showModal() {
+      this.setAttribute('open', '')
+    }
+    dialogProto.close = function close() {
+      this.removeAttribute('open')
+    }
+    try {
+      const { host } = await mountMessage({
+        id: 'user-image',
+        role: 'user',
+        content: '看这张图',
+        timestamp: Date.now(),
+        attachments: [attachment],
+      })
+      await vi.waitFor(() => {
+        expect(host.querySelector('img[alt="image.png"]')?.getAttribute('src')).toBe(dataUrl)
+      })
+      expect(host.textContent ?? '').not.toContain('37.0 KB')
+      host.querySelector<HTMLButtonElement>('[data-testid="message-attachment-image"]')?.click()
+      await nextTick()
+      const dialog = host.querySelector<HTMLDialogElement>('.agent-attachment-lightbox')
+      expect(dialog?.hasAttribute('open')).toBe(true)
+      expect(dialog?.querySelector('img')?.getAttribute('src')).toBe(dataUrl)
+      host.querySelector<HTMLButtonElement>('[data-testid="message-attachment-close"]')?.click()
+      await nextTick()
+      expect(dialog?.hasAttribute('open')).toBe(false)
+    } finally {
+      dialogProto.showModal = previousShow
+      dialogProto.close = previousClose
+    }
   })
 
   it('renders a Beautiful UI choice card and emits the selected option', async () => {

--- a/app/src/components-vue/ChatMessageItem.vue
+++ b/app/src/components-vue/ChatMessageItem.vue
@@ -20,7 +20,7 @@ import { isBlankAssistantMessage } from '@/lib/chatActivity'
 import { isAskMessage, parseAskOptions } from '@/lib/agentAsk'
 import { toolBudgetToolName } from '@/lib/toolBudget'
 import { t } from '@/lib/uiLocale'
-import type { Message } from '@/types'
+import type { CodingAttachment, CodingAttachmentPreview, Message } from '@/types'
 
 const props = defineProps<{
   message: Message
@@ -43,7 +43,108 @@ const editing = ref(false)
 const draft = ref('')
 const copied = ref(false)
 const approvalPinned = ref(false)
+const imagePreviewUrls = ref<Record<string, string>>({})
+const attachmentLightbox = ref<HTMLDialogElement | null>(null)
+const lightboxPreview = ref<CodingAttachmentPreview | null>(null)
 let copyReset = 0
+let previewLoad = 0
+
+function isImageAttachment(attachment: CodingAttachment) {
+  return attachment.mediaType.startsWith('image/')
+}
+
+function attachmentKey(attachment: CodingAttachment) {
+  return attachment.sha256 || attachment.id
+}
+
+const imageAttachments = computed(() => (
+  (props.message.attachments ?? []).filter(isImageAttachment)
+))
+const fileAttachments = computed(() => (
+  (props.message.attachments ?? []).filter(attachment => !isImageAttachment(attachment))
+))
+
+function imagePreviewUrl(attachment: CodingAttachment) {
+  return imagePreviewUrls.value[attachmentKey(attachment)] ?? ''
+}
+
+async function loadImagePreviews() {
+  const images = imageAttachments.value
+  if (!images.length) return
+  const load = ++previewLoad
+  const next = { ...imagePreviewUrls.value }
+  await Promise.all(images.map(async attachment => {
+    const key = attachmentKey(attachment)
+    if (next[key]) return
+    try {
+      const preview = await invokeCommand<CodingAttachmentPreview>(
+        'preview_coding_attachment',
+        { attachment },
+      )
+      if (load !== previewLoad) return
+      if (preview.kind === 'image' && preview.dataUrl) next[key] = preview.dataUrl
+    } catch {
+      // Keep the filename chip when the stored image cannot be read.
+    }
+  }))
+  if (load === previewLoad) imagePreviewUrls.value = next
+}
+
+watch(imageAttachments, () => {
+  void loadImagePreviews()
+}, { immediate: true })
+
+function openAttachmentLightbox() {
+  const dialog = attachmentLightbox.value
+  if (!dialog) return
+  if (typeof dialog.showModal === 'function') dialog.showModal()
+  else dialog.setAttribute('open', '')
+}
+
+function closeAttachmentPreview() {
+  lightboxPreview.value = null
+  const dialog = attachmentLightbox.value
+  if (!dialog) return
+  if (typeof dialog.close === 'function') dialog.close()
+  else dialog.removeAttribute('open')
+}
+
+async function openAttachmentPreview(attachment: CodingAttachment) {
+  const cached = imagePreviewUrl(attachment)
+  if (cached) {
+    lightboxPreview.value = {
+      name: attachment.name,
+      mediaType: attachment.mediaType,
+      size: attachment.size,
+      kind: 'image',
+      dataUrl: cached,
+    }
+    openAttachmentLightbox()
+    return
+  }
+  try {
+    const preview = await invokeCommand<CodingAttachmentPreview>(
+      'preview_coding_attachment',
+      { attachment },
+    )
+    lightboxPreview.value = preview
+    if (preview.kind === 'image' && preview.dataUrl) {
+      imagePreviewUrls.value = {
+        ...imagePreviewUrls.value,
+        [attachmentKey(attachment)]: preview.dataUrl,
+      }
+    }
+    openAttachmentLightbox()
+  } catch {
+    lightboxPreview.value = {
+      name: attachment.name,
+      mediaType: attachment.mediaType,
+      size: attachment.size,
+      kind: 'metadata',
+    }
+    openAttachmentLightbox()
+  }
+}
 
 const sessionTreeUnavailable = computed(() => props.kernel === 'dsh')
 const rewindControlDisabled = computed(() => (
@@ -246,6 +347,8 @@ const replyElapsed = computed(() => {
   return formatDemoElapsed(Math.max(0, replyNow.value - started))
 })
 onBeforeUnmount(() => {
+  previewLoad += 1
+  window.clearTimeout(copyReset)
   window.clearInterval(thinkingClock)
   window.clearInterval(replyClock)
 })
@@ -432,8 +535,29 @@ const approvalKicker = computed(() => (
         class="mb-2 flex flex-wrap gap-2"
         :aria-label="t('消息附件', 'Message attachments')"
       >
+        <button
+          v-for="attachment in imageAttachments"
+          :key="`${attachment.id}:${attachment.name}`"
+          type="button"
+          class="agent-attachment-thumb"
+          data-testid="message-attachment-image"
+          :aria-label="t(`查看 ${attachment.name}`, `View ${attachment.name}`)"
+          :title="attachment.name"
+          @click="openAttachmentPreview(attachment)"
+        >
+          <img
+            v-if="imagePreviewUrl(attachment)"
+            :src="imagePreviewUrl(attachment)"
+            :alt="attachment.name"
+          >
+          <span v-else class="agent-attachment">
+            <FileText class="size-3.5 shrink-0" />
+            <span class="truncate">{{ attachment.name }}</span>
+            <span class="shrink-0 opacity-65">{{ formatAttachmentSize(attachment.size) }}</span>
+          </span>
+        </button>
         <span
-          v-for="attachment in message.attachments"
+          v-for="attachment in fileAttachments"
           :key="`${attachment.id}:${attachment.name}`"
           class="agent-attachment"
           :title="`${attachment.mediaType} · sha256:${attachment.sha256}`"
@@ -558,5 +682,32 @@ const approvalKicker = computed(() => (
         <GitFork />
       </button>
     </div>
+    <dialog
+      ref="attachmentLightbox"
+      class="agent-attachment-lightbox"
+      :aria-label="t('图片预览', 'Image preview')"
+      @click.self="closeAttachmentPreview"
+      @cancel.prevent="closeAttachmentPreview"
+    >
+      <header class="agent-attachment-lightbox__bar">
+        <p class="truncate">{{ lightboxPreview?.name || t('图片预览', 'Image preview') }}</p>
+        <button
+          type="button"
+          data-testid="message-attachment-close"
+          :aria-label="t('关闭', 'Close')"
+          @click="closeAttachmentPreview"
+        >
+          <X class="size-4" />
+        </button>
+      </header>
+      <img
+        v-if="lightboxPreview?.kind === 'image' && lightboxPreview.dataUrl"
+        :src="lightboxPreview.dataUrl"
+        :alt="lightboxPreview.name"
+      >
+      <p v-else class="agent-attachment-lightbox__empty">
+        {{ t('这张图片暂时无法预览。', 'This image cannot be previewed right now.') }}
+      </p>
+    </dialog>
   </article>
 </template>

--- a/app/src/components-vue/WorkspaceVisualContract.test.ts
+++ b/app/src/components-vue/WorkspaceVisualContract.test.ts
@@ -85,6 +85,8 @@ describe('Workspace visual contract', () => {
     expect(chatPageSource).not.toContain('展开会话历史')
     expect(chatMessageItemSource).toContain('break-words text-control leading-7')
     expect(chatMessageItemSource).toContain('agent-attachment')
+    expect(chatMessageItemSource).toContain('agent-attachment-thumb')
+    expect(chatMessageItemSource).toContain('agent-attachment-lightbox')
     expect(chatMessageItemSource).not.toContain('rounded-lg border border-current/15')
     expect(chatMessageItemSource).not.toContain('YOU')
     expect(chatMessageItemSource).not.toContain('MILKSU')

--- a/app/src/styles/agent-conversation.css
+++ b/app/src/styles/agent-conversation.css
@@ -440,6 +440,94 @@
   font-size: 0.8rem;
 }
 
+[data-agent-conversation] .agent-attachment-thumb {
+  display: block;
+  max-width: 12rem;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  color: inherit;
+  cursor: zoom-in;
+}
+
+[data-agent-conversation] .agent-attachment-thumb img {
+  display: block;
+  max-width: 12rem;
+  max-height: 8rem;
+  object-fit: cover;
+}
+
+[data-agent-conversation] .agent-attachment-thumb .agent-attachment {
+  padding: 0.45rem 0.6rem;
+}
+
+[data-agent-conversation] .agent-attachment-lightbox {
+  inset: 0;
+  max-width: min(48rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 3rem);
+  margin: auto;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-overlay);
+  color: var(--popover-foreground);
+}
+
+[data-agent-conversation] .agent-attachment-lightbox::backdrop {
+  background: color-mix(in oklab, var(--foreground) 32%, transparent);
+}
+
+[data-agent-conversation] .agent-attachment-lightbox__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+[data-agent-conversation] .agent-attachment-lightbox__bar p {
+  min-width: 0;
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+[data-agent-conversation] .agent-attachment-lightbox__bar button {
+  display: grid;
+  flex: none;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+}
+
+[data-agent-conversation] .agent-attachment-lightbox__bar button:hover {
+  background: var(--hover-2);
+}
+
+[data-agent-conversation] .agent-attachment-lightbox img {
+  display: block;
+  max-width: 100%;
+  max-height: calc(100vh - 8rem);
+  margin: 0 auto;
+  padding: 0.85rem;
+  object-fit: contain;
+}
+
+[data-agent-conversation] .agent-attachment-lightbox__empty {
+  margin: 0;
+  padding: 1.25rem 0.85rem 1.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
+}
+
 [data-agent-conversation] .agent-choice {
   width: 100%;
 }


### PR DESCRIPTION
已发送的图片附件不再只显示 `image.png` 和体积。消息里先出现缩略图，点击打开不透明 overlay 大图，关闭按钮或点遮罩退出。非图片附件仍是文件名和大小。

```text
cd app && npx vitest run src/components-vue/ChatMessageItem.test.ts \
  src/components-vue/WorkspaceVisualContract.test.ts \
  src/lib/uiLocaleCoverage.test.ts
```