### PR TITLE
ci(windows): 发版前只原生编译，不再为所有测试链一遍

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -81,10 +81,9 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           # The canonical full suite is already bound to this commit by the
-          # local release receipt. Windows compiles every Go package/test, then
-          # exercises the routed model regression with native paths before
-          # packaging and first launch.
-          go test ./... -run '^$'
+          # local release receipt. Windows compiles production packages natively,
+          # then exercises Windows-only startup, CUA and routing before packaging.
+          go build ./...
           go test ./cmd/milksu-backend -run '^TestWindowsStartupDoesNotRequireGit$' -count=1
           node --test --test-isolation=none desktop/startup-environment.test.cjs desktop/package-files.test.cjs
           node --test sidecar/pi/current-provider-runtime.test.js sidecar/pi/model-source-routing.test.js


### PR DESCRIPTION
Windows 发版 job 里 `go test ./... -run '^$'` 大约 8.5 分钟，只是为了在 Windows 上把所有测试二进制也编译一遍。全仓测试已经由本机 `release:verify` 绑定。

改成 `go build ./...`，并保留：

- `TestWindowsStartupDoesNotRequireGit`
- CUA driver verify + `computercap` 测试
- 路由相关 sidecar 测试
- 打包后的首次启动验收

不改 macOS 公证、Linux 三发行版试装，也不加 Sidecar 缓存。