### PR TITLE
ci: 三端发版缓存 Sidecar 下载和 Electron zip

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -30,6 +30,9 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/build/caches/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/build/caches/electron-builder
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,6 +63,22 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Cache Sidecar downloads
+        uses: actions/cache@v4
+        with:
+          path: build/sidecar-cache
+          key: sidecar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/package-sidecar.mjs', 'scripts/build-windows-cua-driver.mjs', 'package-lock.json', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            sidecar-${{ runner.os }}-${{ runner.arch }}-
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/caches/electron
+            build/caches/electron-builder
+          key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ${{ inputs.use_self_hosted && fromJSON('["self-hosted","macOS","ARM64"]') || fromJSON('["macos-15"]') }}
     timeout-minutes: 180
     environment: macos-release
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/build/caches/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/build/caches/electron-builder
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,6 +83,24 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+      - name: Cache Sidecar downloads
+        if: ${{ !inputs.use_self_hosted }}
+        uses: actions/cache@v4
+        with:
+          path: build/sidecar-cache
+          key: sidecar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/package-sidecar.mjs', 'scripts/build-windows-cua-driver.mjs', 'package-lock.json', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            sidecar-${{ runner.os }}-${{ runner.arch }}-
+      - name: Cache Electron downloads
+        if: ${{ !inputs.use_self_hosted }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/caches/electron
+            build/caches/electron-builder
+          key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,6 +30,9 @@ jobs:
   release:
     runs-on: windows-2025
     timeout-minutes: 90
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/build/caches/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/build/caches/electron-builder
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,10 +68,22 @@ jobs:
           go-version-file: go.mod
           cache: true
       - uses: dtolnay/rust-toolchain@1.97.1
-      - uses: actions/cache@v4
+      - name: Cache Sidecar downloads
+        uses: actions/cache@v4
         with:
-          path: build/sidecar-cache/cua-windows-0.27.0/h
-          key: windows-cua-0.27.0-${{ hashFiles('scripts/build-windows-cua-driver.mjs', 'third_party/cua-driver/**') }}
+          path: build/sidecar-cache
+          key: sidecar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/package-sidecar.mjs', 'scripts/build-windows-cua-driver.mjs', 'package-lock.json', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            sidecar-${{ runner.os }}-${{ runner.arch }}-
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/caches/electron
+            build/caches/electron-builder
+          key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ runner.arch }}-
       - name: Install dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -43,8 +43,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.97.1
       - uses: actions/cache@v4
         with:
-          path: build/sidecar-cache/cua-windows-0.27.0/h
-          key: windows-cua-0.27.0-${{ hashFiles('scripts/build-windows-cua-driver.mjs', 'third_party/cua-driver/**') }}
+          path: build/sidecar-cache
+          key: sidecar-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/package-sidecar.mjs', 'scripts/build-windows-cua-driver.mjs', 'package-lock.json', 'go.mod', 'go.sum') }}
+          restore-keys: |
+            sidecar-${{ runner.os }}-${{ runner.arch }}-
       - name: Check backend formatting
         shell: pwsh
         run: |


### PR DESCRIPTION
本机打包快是因为 `build/sidecar-cache` 和 Electron zip 已经在盘上。云端每次空 runner，Linux 打包约 8 分钟、Windows sidecar/CUA 段也重。

这次给 macOS / Windows / Linux 发版（以及 Windows startup）加上：

- `build/sidecar-cache`：Node、gopls、CUA、gomodcache，按 `package-sidecar.mjs` / CUA 脚本 / lockfile / `go.mod` 哈希
- `build/caches/electron` 与 `electron-builder`：按 `desktop/package-lock.json` 哈希，并用 `ELECTRON_CACHE` / `ELECTRON_BUILDER_CACHE` 指到仓库内

Windows 原先只缓存 CUA 的 cargo home，并进整棵 sidecar-cache，和 startup job 共用。macOS 自托管 runner 仍不走远程缓存。

第一次发版仍是冷的，从第二次开始才省下载。不改公证、不改 `go build` 那条（#75）、不改发行文档。